### PR TITLE
Correct spelling error in API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,4 +1,4 @@
-Making Reqeusts
+Making Requests
 ===============
 
 .. module:: treq


### PR DESCRIPTION
Change "Reqeusts" to "Requests".
