### PR TITLE
Allow aborting a collect() early

### DIFF
--- a/treq/__init__.py
+++ b/treq/__init__.py
@@ -1,9 +1,11 @@
 from pkg_resources import resource_string
 
 from treq.api import head, get, post, put, patch, delete, request
-from treq.content import collect, content, text_content, json_content
+from treq.content import (
+    collect, content, text_content, json_content, CollectorResult)
 
 __all__ = ['head', 'get', 'post', 'put', 'patch', 'delete', 'request',
-           'collect', 'content', 'text_content', 'json_content']
+           'collect', 'content', 'text_content', 'json_content',
+           'CollectorResult']
 
 __version__ = resource_string(__name__, "_version").strip()


### PR DESCRIPTION
If part way through a collect() you decide you've had enough data there is no convenient way to stop the rest of the collection process from the collector.
