### PR TITLE
Moved agent wrapping to HTTPClient.request. Adjusted module-api helper

### DIFF
--- a/treq/api.py
+++ b/treq/api.py
@@ -102,17 +102,9 @@ def request(method, url, **kwargs):
 #
 
 def _client(*args, **kwargs):
-    kwargs['pool'] = default_pool(kwargs.get('reactor'),
-                                  kwargs.get('pool'),
-                                  kwargs.get('persistent'))
-
     reactor = default_reactor(kwargs.get('reactor'))
-
-    pool = kwargs.get('pool')
-    if not pool:
-        persistent = kwargs.get('persistent', True)
-        pool = HTTPConnectionPool(reactor, persistent=persistent)
-
+    pool = default_pool(reactor,
+                        kwargs.get('pool'),
+                        kwargs.get('persistent'))
     agent = Agent(reactor, pool=pool)
-
     return HTTPClient(agent)

--- a/treq/client.py
+++ b/treq/client.py
@@ -30,6 +30,9 @@ from treq import multipart
 from treq.response import _Response
 
 
+def wrap_agent_with_gzip(agent):
+    return ContentDecoderAgent(wrapped_agent, [('gzip', GzipDecoder)])
+
 class _BodyBufferingProtocol(proxyForInterface(IProtocol)):
     def __init__(self, original, buffer, finished):
         self.original = original
@@ -162,8 +165,6 @@ class HTTPClient(object):
 
         if kwargs.get('allow_redirects', True):
             wrapped_agent = RedirectAgent(wrapped_agent)
-
-        wrapped_agent = ContentDecoderAgent(wrapped_agent, [('gzip', GzipDecoder)])
 
         auth = kwargs.get('auth')
         if auth:


### PR DESCRIPTION
This breaks various tests, because I assume the tests are not expecting the gzip related headers. What is your take on how to fix the broken tests?
