### PR TITLE
Added HTTP proxy support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 htmlcov
 _trial_temp
 .tox
+.idea/

--- a/docs/examples/digest_auth.py
+++ b/docs/examples/digest_auth.py
@@ -1,0 +1,16 @@
+from twisted.internet.task import react
+from _utils import print_response
+
+import treq
+from treq.auth import HTTPDigestAuth
+
+
+def main(reactor, *args):
+    d = treq.get(
+        'http://httpbin.org/digest-auth/auth/treq/treq',
+        auth=HTTPDigestAuth('treq', 'treq')
+    )
+    d.addCallback(print_response)
+    return d
+
+react(main, [])

--- a/docs/examples/proxy_with_authentication.py
+++ b/docs/examples/proxy_with_authentication.py
@@ -1,0 +1,16 @@
+from twisted.internet.task import react
+from _utils import print_response
+
+import treq
+
+
+def main(reactor, *args):
+    d = treq.get(
+        'http://httpbin.org/get',
+        proxy=('localhost', 8123),
+        proxy_auth=('treq', 'treq')
+    )
+    d.addCallback(print_response)
+    return d
+
+react(main, [])

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -53,12 +53,14 @@ The ``auth`` argument should be a tuple of the form ``('username', 'password')``
 Full example: :download:`basic_auth.py <examples/basic_auth.py>`
 
 HTTP Digest authentication is supported by passing an instance of
-:py:class:`treq.auth.HTTPDigestAuth` class with ``auth`` keyword argument to any of
-the request functions. We support only "auth" QoP as defined at `RFC 2617`_
-or simple `RFC 2069`_ without QoP at the moment. Treq takes care about
-HTTP digest credentials caching - after authorization on any URL/method pair,
-the library will use the first time received HTTP digest credentials on that endpoint
-for further requests, and will not perform any redundant requests for obtaining the creds.
+:py:class:`treq.auth.HTTPDigestAuth` class with ``auth`` keyword argument
+to any of the request functions.
+We support only "auth" QoP as defined at `RFC 2617`_ or simple `RFC 2069`_
+without QoP at the moment. treq takes care about HTTP digest credentials
+caching - after authorization on any URL/method pair, the library will use
+the first time received HTTP digest credentials on that endpoint
+for further requests, and will not perform
+any redundant requests for obtaining the creds.
 
 :py:class:`treq.auth.HTTPDigestAuth` class accepts ``username`` and ``password``
 as constructor arguments.
@@ -103,6 +105,25 @@ the `history()` method on the the response.
 
 Full example: :download:`response_history.py <examples/response_history.py>`
 
+Proxies
+-------
+
+treq supports only pure HTTP proxies at the moment.
+Proxy to be used when performing a request can be specified by passing
+a ``proxy`` keyword to any of the request functions. treq also supports
+Basic proxy authentication - you can pass ``proxy_auth`` keyword arguments
+to the request function in the same form as HTTP Basic authentication works with
+treq.
+
+The following will use the proxy running at the localhost port 8123,
+which configured to authenticate clients
+with username 'treq' and password 'treq'
+
+.. literalinclude:: examples/proxy_with_authentication.py
+    :linenos:
+    :lines: 7-14
+
+Full example: :download:`proxy_with_authentication.py <examples/proxy_with_authentication.py>`
 
 Cookies
 -------

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -52,7 +52,25 @@ The ``auth`` argument should be a tuple of the form ``('username', 'password')``
 
 Full example: :download:`basic_auth.py <examples/basic_auth.py>`
 
+HTTP Digest authentication is supported by passing an instance of
+:py:class:`treq.auth.HTTPDigestAuth` class with ``auth`` keyword argument to any of
+the request functions. We support only "auth" QoP as defined at `RFC 2617`_
+or simple `RFC 2069`_ without QoP at the moment. Treq takes care about
+HTTP digest credentials caching - after authorization on any URL/method pair,
+the library will use the first time received HTTP digest credentials on that endpoint
+for further requests, and will not perform any redundant requests for obtaining the creds.
+
+:py:class:`treq.auth.HTTPDigestAuth` class accepts ``username`` and ``password``
+as constructor arguments.
+
+.. literalinclude:: examples/digest_auth.py
+    :linenos:
+    :lines: 5-14
+
+Full example: :download:`digest_auth.py <examples/digest_auth.py>`
+
 .. _RFC 2617: http://www.ietf.org/rfc/rfc2617.txt
+.. _RFC 2069: http://www.ietf.org/rfc/rfc2069.txt
 
 Redirects
 ---------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,7 +82,7 @@ features is.  Here is a list of `requests`_ features and their status in treq.
 +----------------------------------+----------+----------+
 | Basic Authentication             | yes      | yes      |
 +----------------------------------+----------+----------+
-| Digest Authentication            | yes      | no       |
+| Digest Authentication            | yes      | yes      |
 +----------------------------------+----------+----------+
 | Elegant Key/Value Cookies        | yes      | yes      |
 +----------------------------------+----------+----------+

--- a/treq/api.py
+++ b/treq/api.py
@@ -118,7 +118,7 @@ def _client(*args, **kwargs):
     pool = default_pool(reactor,
                         kwargs.get('pool'),
                         kwargs.get('persistent'))
-    if 'proxy' in kwargs.keys():
+    if 'proxy' in kwargs:
         address, port = kwargs.get('proxy')
         endpoint = TCP4ClientEndpoint(reactor, address, port)
         agent = ProxyAgent(endpoint, pool=pool)

--- a/treq/api.py
+++ b/treq/api.py
@@ -1,4 +1,5 @@
-from twisted.web.client import Agent
+from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.web.client import Agent, ProxyAgent
 
 from treq.client import HTTPClient
 from treq._utils import default_pool, default_reactor
@@ -84,12 +85,19 @@ def request(method, url, **kwargs):
     :param bool persistent: Use persistent HTTP connections.  Default: ``True``
     :param bool allow_redirects: Follow HTTP redirects.  Default: ``True``
 
-    :param auth: HTTP Basic Authentication information.
-    :type auth: tuple of ``('username', 'password')``.
+    :param auth: HTTP Authentication information (Basic or Digest).
+    :type auth: tuple of ``('username', 'password')`` or instance of
+        ``treq.auth.HTTPDigestAuth`` class
 
     :param cookies: Cookies to send with this request.  The HTTP kind, not the
         tasty kind.
     :type cookies: ``dict`` or ``cookielib.CookieJar``
+
+    :param proxy: Specifies HTTP proxy to use.
+    :type proxy: typle of ``(`host`, `port`)``
+
+    :param proxy_auth: Specifies Basic Proxy Authentication information
+    :type proxy_auth: tuple of ``('username', 'password')``
 
     :param int timeout: Request timeout seconds. If a response is not
         received within this timeframe, a connection is aborted with
@@ -110,5 +118,10 @@ def _client(*args, **kwargs):
     pool = default_pool(reactor,
                         kwargs.get('pool'),
                         kwargs.get('persistent'))
-    agent = Agent(reactor, pool=pool)
+    if 'proxy' in kwargs.keys():
+        address, port = kwargs.get('proxy')
+        endpoint = TCP4ClientEndpoint(reactor, address, port)
+        agent = ProxyAgent(endpoint, pool=pool)
+    else:
+        agent = Agent(reactor, pool=pool)
     return HTTPClient(agent)

--- a/treq/auth.py
+++ b/treq/auth.py
@@ -1,11 +1,131 @@
-from twisted.web.http_headers import Headers
+import re
+
+import time
 import base64
+import hashlib
+import urlparse
+
+from twisted.web.http_headers import Headers
+from twisted.python.randbytes import secureRandom
+from requests.utils import parse_dict_header
+
+
+_DIGEST_HEADER_PREFIX_REGEXP = re.compile(r'digest ', flags=re.IGNORECASE)
+
+
+def generate_client_nonce(server_side_nonce):
+    return hashlib.sha1(
+        hashlib.sha1(server_side_nonce).digest() + secureRandom(16) + time.ctime()
+    ).hexdigest()[:16]
+
+
+def _md5_utf_digest(x):
+    if isinstance(x, str):
+        x = x.encode('utf-8')
+    return hashlib.md5(x).hexdigest()
+
+
+def _sha1_utf_digest(x):
+    if isinstance(x, str):
+        x = x.encode('utf-8')
+    return hashlib.sha1(x).hexdigest()
+
+
+def build_digest_authentication_header(agent, **kwargs):
+    algo = kwargs.get('algorithm', 'MD5').upper()
+    original_algo = kwargs.get('algorithm')
+    qop = kwargs.get('qop', None)
+    nonce = kwargs.get('nonce')
+    opaque = kwargs.get('opaque', None)
+    path_parsed = urlparse.urlparse(kwargs['path'])
+    actual_path = path_parsed.path
+
+    if path_parsed.query:
+        actual_path += '?' + path_parsed.query
+
+    a1 = '%s:%s:%s' % (
+        agent.username,
+        kwargs['realm'],
+        agent.password
+    )
+
+    a2 = '%s:%s' % (
+        kwargs['method'],
+        actual_path
+    )
+
+    if algo == 'MD5' or algo == 'MD5-SESS':
+        digest_hash_func = _md5_utf_digest
+    elif algo == 'SHA':
+        digest_hash_func = _sha1_utf_digest
+    else:
+        raise UnknownDigestAuthAlgorithm(algo)
+
+    ha1 = digest_hash_func(a1)
+    ha2 = digest_hash_func(a2)
+
+    cnonce = generate_client_nonce(nonce)
+
+    if algo == 'MD5-SESS':
+        ha1 = digest_hash_func("%s:%s:%s" % (ha1, nonce, cnonce), algo)
+
+    if kwargs['cached']:
+        agent.digest_auth_cache[(kwargs['method'], kwargs['path'])]['c'] += 1
+        nonce_count = agent.digest_auth_cache[(kwargs['method'], kwargs['path'])]['c']
+    else:
+        nonce_count = 1
+
+    ncvalue = '%08x' % nonce_count
+    if qop is None:
+        response_digest = digest_hash_func("%s:%s" % (ha1, "%s:%s" % (ha2, nonce)))
+    else:
+        noncebit = "%s:%s:%s:%s:%s" % (nonce, ncvalue, cnonce.encode('utf-8'), 'auth', ha2)
+        response_digest = digest_hash_func("%s:%s" % (ha1, noncebit))
+
+    header_base = 'username="%s", realm="%s", nonce="%s", uri="%s", response="%s"' % (
+        agent.username, kwargs['realm'], nonce, actual_path, response_digest
+    )
+    if opaque:
+        header_base += ', opaque="%s"' % opaque
+    if original_algo:
+        header_base += ', algorithm="%s"' % original_algo
+    if qop:
+        header_base += ', qop="auth", nc=%s, cnonce="%s"' % (ncvalue, cnonce)
+    if not kwargs['cached']:
+        agent.digest_auth_cache[(kwargs['method'], kwargs['path'])] = {
+            'p': kwargs,
+            'c': 1
+        }
+    return 'Digest %s' % header_base
+
+
+class HTTPDigestAuth(object):
+
+    def __init__(self, username, password):
+        self.username = username
+        self.password = password
 
 
 class UnknownAuthConfig(Exception):
     def __init__(self, config):
         super(Exception, self).__init__(
             '{0!r} not of a known type.'.format(config))
+
+
+class UnknownQopForDigestAuth(Exception):
+
+    def __init__(self, qop):
+        super(Exception, self).__init__(
+            'Unsupported Quality Of Protection value passed: {qop}'.format(qop=qop)
+        )
+
+
+class UnknownDigestAuthAlgorithm(Exception):
+
+    def __init__(self, algorithm):
+        super(Exception, self).__init__(
+            'Unsupported Digest Auth algorithm identifier passed: {algorithm}'.format(algorithm=algorithm)
+        )
 
 
 class _RequestHeaderSettingAgent(object):
@@ -24,11 +144,70 @@ class _RequestHeaderSettingAgent(object):
             method, uri, headers=headers, bodyProducer=bodyProducer)
 
 
+class _RequestDigestAuthenticationAgent(object):
+
+    digest_auth_cache = {}
+
+    def __init__(self, agent, username, password):
+        self._agent = agent
+        self.username = username
+        self.password = password
+
+    def _on_401_response(self, www_authenticate_response, method, uri, headers, bodyProducer):
+        assert www_authenticate_response.code == 401, """Got invalid pre-authentication response code, probably URL
+                                                        does not support Digest auth
+                                                      """
+        www_authenticate_header_string = www_authenticate_response.headers._rawHeaders.get('www-authenticate', [''])[0]
+        digest_authentication_params = parse_dict_header(
+            _DIGEST_HEADER_PREFIX_REGEXP.sub('', www_authenticate_header_string, count=1)
+        )
+        if digest_authentication_params.get('qop', None) is not None and \
+            digest_authentication_params['qop'] != 'auth' and \
+                'auth' not in digest_authentication_params['qop'].split(','):
+            # We support only "auth" QoP as defined in rfc-2617 or rfc-2069
+            raise UnknownQopForDigestAuth(digest_authentication_params['qop'])
+        digest_authentication_header = build_digest_authentication_header(
+            self,
+            path=uri,
+            method=method,
+            cached=False,
+            **digest_authentication_params
+        )
+        return self._perform_request(
+            digest_authentication_header, method, uri, headers, bodyProducer
+        )
+
+    def _perform_request(self, digest_authentication_header, method, uri, headers, bodyProducer):
+        if not headers:
+            headers = Headers({'Authorization': digest_authentication_header})
+        else:
+            headers.addRawHeader('Authorization', digest_authentication_header)
+        return self._agent.request(
+            method, uri, headers=headers, bodyProducer=bodyProducer
+        )
+
+    def request(self, method, uri, headers=None, bodyProducer=None):
+        if self.digest_auth_cache.get((method, uri), None) is None:
+            # Perform first request for getting the realm; the client awaits for 401 response code here
+            d = self._agent.request(method, uri, headers=headers, bodyProducer=None)
+            d.addCallback(self._on_401_response, method, uri, headers, bodyProducer)
+        else:
+            digest_params_from_cache = self.digest_auth_cache.get((method, uri))['p']
+            digest_params_from_cache['cached'] = True
+            digest_authentication_header = build_digest_authentication_header(self, **digest_params_from_cache)
+            d = self._perform_request(digest_authentication_header, method, uri, headers, bodyProducer)
+        return d
+
+
 def add_basic_auth(agent, username, password):
     creds = base64.b64encode('{0}:{1}'.format(username, password))
     return _RequestHeaderSettingAgent(
         agent,
         Headers({'Authorization': ['Basic {0}'.format(creds)]}))
+
+
+def add_digest_auth(agent, http_digest_auth):
+    return _RequestDigestAuthenticationAgent(agent, http_digest_auth.username, http_digest_auth.password)
 
 
 def add_auth(agent, auth_config):

--- a/treq/auth.py
+++ b/treq/auth.py
@@ -1,5 +1,4 @@
 import re
-
 import time
 import base64
 import hashlib
@@ -299,5 +298,24 @@ def add_digest_auth(agent, http_digest_auth):
 def add_auth(agent, auth_config):
     if isinstance(auth_config, tuple):
         return add_basic_auth(agent, auth_config[0], auth_config[1])
+    elif isinstance(auth_config, HTTPDigestAuth):
+        return add_digest_auth(agent, auth_config)
 
     raise UnknownAuthConfig(auth_config)
+
+
+def add_basic_proxy_auth(agent, username, password):
+    creds = base64.b64encode('{0}:{1}'.format(username, password))
+    return _RequestHeaderSettingAgent(
+        agent,
+        Headers({'Proxy-Authorization': ['Basic {0}'.format(creds)]})
+    )
+
+
+def add_proxy_auth(agent, proxy_auth_config):
+    if isinstance(proxy_auth_config, tuple):
+        return add_basic_proxy_auth(
+            agent, proxy_auth_config[0], proxy_auth_config[1]
+        )
+
+    raise UnknownAuthConfig(proxy_auth_config)

--- a/treq/client.py
+++ b/treq/client.py
@@ -26,7 +26,7 @@ from twisted.web.client import (
 from twisted.python.components import registerAdapter
 
 from treq._utils import default_reactor
-from treq.auth import add_auth
+from treq.auth import HTTPDigestAuth, add_auth, add_digest_auth
 from treq import multipart
 from treq.response import _Response
 
@@ -179,7 +179,9 @@ class HTTPClient(object):
                                             [('gzip', GzipDecoder)])
 
         auth = kwargs.get('auth')
-        if auth:
+        if isinstance(auth, HTTPDigestAuth):
+            wrapped_agent = add_digest_auth(wrapped_agent, auth)
+        elif auth:
             wrapped_agent = add_auth(wrapped_agent, auth)
 
         d = wrapped_agent.request(

--- a/treq/client.py
+++ b/treq/client.py
@@ -16,6 +16,7 @@ from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer, IResponse
 
 from twisted.web.client import (
+    ProxyAgent,
     FileBodyProducer,
     RedirectAgent,
     ContentDecoderAgent,
@@ -26,7 +27,7 @@ from twisted.web.client import (
 from twisted.python.components import registerAdapter
 
 from treq._utils import default_reactor
-from treq.auth import HTTPDigestAuth, add_auth, add_digest_auth
+from treq.auth import add_auth, add_proxy_auth
 from treq import multipart
 from treq.response import _Response
 
@@ -178,10 +179,13 @@ class HTTPClient(object):
         wrapped_agent = ContentDecoderAgent(wrapped_agent,
                                             [('gzip', GzipDecoder)])
 
+        if isinstance(self._agent, ProxyAgent) and 'proxy_auth' in kwargs:
+            wrapped_agent = add_proxy_auth(
+                wrapped_agent, kwargs['proxy_auth']
+            )
+
         auth = kwargs.get('auth')
-        if isinstance(auth, HTTPDigestAuth):
-            wrapped_agent = add_digest_auth(wrapped_agent, auth)
-        elif auth:
+        if auth:
             wrapped_agent = add_auth(wrapped_agent, auth)
 
         d = wrapped_agent.request(

--- a/treq/test/_proxyutil.py
+++ b/treq/test/_proxyutil.py
@@ -23,7 +23,14 @@ class TestProxyRequestFactory(ProxyRequest):
         parsed = urlparse.urlparse(self.uri)
         protocol = parsed[0]
         host = parsed[1]
-        port = self.ports[protocol]
+        try:
+            port = self.ports[protocol]
+        except KeyError, e:
+            self.transport.write(
+                "bHTTP/1.1 400 Bad Request\r\n\r\n"
+            )
+            self.transport.loseConnection()
+            return
         if ':' in host:
             host, port = host.split(':')
             port = int(port)

--- a/treq/test/_proxyutil.py
+++ b/treq/test/_proxyutil.py
@@ -1,0 +1,144 @@
+import re
+import base64
+import urlparse
+
+from twisted.web.proxy import Proxy, ProxyRequest
+from twisted.web.http import HTTPFactory
+
+
+def with_baseurl_and_proxy(method):
+
+    def _request(self, url, *args, **kwargs):
+        kwargs.update({'proxy': self.proxy_params})
+        return method(self.baseurl + url, *args, pool=self.pool, **kwargs)
+
+    return _request
+
+
+class TestProxyRequestFactory(ProxyRequest):
+
+    def process(self):
+        # We need to override this method since the original twisted.web.proxy
+        # lacks support of sending multiple header values
+        parsed = urlparse.urlparse(self.uri)
+        protocol = parsed[0]
+        host = parsed[1]
+        port = self.ports[protocol]
+        if ':' in host:
+            host, port = host.split(':')
+            port = int(port)
+        rest = urlparse.urlunparse(('', '') + parsed[2:])
+        if not rest:
+            rest = rest + '/'
+        class_ = self.protocols[protocol]
+
+        # Here we go:
+
+        headers = {}
+        for k, v in self.requestHeaders.getAllRawHeaders():
+            if len(v) == 1:
+                headers[k.lower()] = v[0]
+            else:
+                headers[k.lower()] = ",".join(v)
+
+        if 'host' not in headers:
+            headers['host'] = host
+        self.content.seek(0, 0)
+        s = self.content.read()
+        clientFactory = class_(self.method, rest, self.clientproto, headers,
+                               s, self)
+        self.reactor.connectTCP(host, port, clientFactory)
+
+    def finish(self):
+        # We need to override this method to do the proper timeout testing,
+        # since twisted.web.proxy fires RuntimeError when receives response
+        # after Treq disconnection; this does not affect the library logic,
+        # but saves us from internal proxy errors
+        try:
+            return ProxyRequest.finish(self)
+        except RuntimeError:
+            pass
+
+
+class TestProxyProtocol(Proxy):
+
+    requestFactory = TestProxyRequestFactory
+
+
+class TestProxyFactory(HTTPFactory):
+
+    def buildProtocol(self, addr):
+        return TestProxyProtocol()
+
+
+class TestProxyRequestFactoryWithAuthentication(ProxyRequest):
+
+    def checkAuthCredentials(self, username, password, proxy_auth_header):
+        creds_serialized = re.sub(r'Basic ', '', proxy_auth_header)
+        return creds_serialized == base64.b64encode(
+            "%s:%s" % (username, password)
+        )
+
+    def process(self):
+        parsed = urlparse.urlparse(self.uri)
+        protocol = parsed[0]
+        host = parsed[1]
+        port = self.ports[protocol]
+        if ':' in host:
+            host, port = host.split(':')
+            port = int(port)
+        rest = urlparse.urlunparse(('', '') + parsed[2:])
+        if not rest:
+            rest = rest + '/'
+        class_ = self.protocols[protocol]
+
+        # Here we go:
+
+        headers = {}
+        for k, v in self.requestHeaders.getAllRawHeaders():
+            if len(v) == 1:
+                headers[k.lower()] = v[0]
+            else:
+                headers[k.lower()] = ",".join(v)
+
+        if 'host' not in headers:
+            headers['host'] = host
+
+        username, password = self.channel.credentials
+
+        if 'proxy-authorization' not in headers or not \
+            self.checkAuthCredentials(
+                username, password, headers['proxy-authorization']
+            ):
+            self.transport.write(
+                "bHTTP/1.1 407 Proxy Authentication Required\r\n\r\n"
+            )
+            self.transport.loseConnection()
+            return
+        else:
+            headers.pop('proxy-authorization')
+
+        self.content.seek(0, 0)
+        s = self.content.read()
+        clientFactory = class_(self.method, rest, self.clientproto, headers,
+                               s, self)
+        self.reactor.connectTCP(host, port, clientFactory)
+
+
+class TestProxyWithAuthentication(Proxy):
+
+    requestFactory = TestProxyRequestFactoryWithAuthentication
+
+    def __init__(self, credentials):
+        self.credentials = credentials
+        Proxy.__init__(self)
+
+
+class TestProxyFactoryWithAuthentication(HTTPFactory):
+
+    def __init__(self, credentials, *args, **kwargs):
+        self.credentials = credentials
+        HTTPFactory.__init__(self, *args, **kwargs)
+
+    def buildProtocol(self, addr):
+        return TestProxyWithAuthentication(self.credentials)

--- a/treq/test/test_auth.py
+++ b/treq/test/test_auth.py
@@ -4,7 +4,8 @@ from twisted.web.client import Agent
 from twisted.web.http_headers import Headers
 
 from treq.test.util import TestCase
-from treq.auth import _RequestHeaderSettingAgent, add_auth, UnknownAuthConfig, HTTPDigestAuth, add_digest_auth
+from treq.auth import _RequestHeaderSettingAgent, add_auth, \
+    UnknownAuthConfig, HTTPDigestAuth, add_digest_auth
 
 
 class RequestHeaderSettingAgentTests(TestCase):
@@ -45,7 +46,9 @@ class RequestHeaderSettingAgentTests(TestCase):
 class AddAuthTests(TestCase):
     def setUp(self):
         self.rhsa_patcher = mock.patch('treq.auth._RequestHeaderSettingAgent')
-        self.rdaa_patcher = mock.patch('treq.auth._RequestDigestAuthenticationAgent')
+        self.rdaa_patcher = mock.patch(
+            'treq.auth._RequestDigestAuthenticationAgent'
+        )
         self._RequestDigestAuthenticationAgent = self.rdaa_patcher.start()
         self._RequestHeaderSettingAgent = self.rhsa_patcher.start()
         self.addCleanup(self.rhsa_patcher.stop)

--- a/treq/test/test_treq_integration.py
+++ b/treq/test/test_treq_integration.py
@@ -291,7 +291,7 @@ class TreqIntegrationTests(TestCase):
         response = yield self.get('/cookies/set',
                                   allow_redirects=False,
                                   params={'hello': 'there'})
-        #self.assertEqual(response.code, 200)
+        # self.assertEqual(response.code, 200)
         yield print_response(response)
         self.assertEqual(response.cookies()['hello'], 'there')
 

--- a/treq/test/test_treq_integration.py
+++ b/treq/test/test_treq_integration.py
@@ -260,7 +260,7 @@ class TreqIntegrationTests(TestCase):
         json2 = yield treq.json_content(response2)
         self.assertTrue(json1['authenticated'])
         self.assertEqual(json1['user'], 'treq-digest-auth-multiple')
-        self.assertDictEqual(json1, json2)
+        self.assertEqual(json1, json2)
 
     @inlineCallbacks
     def test_failed_digest_auth(self):

--- a/treq/test/test_treq_integration.py
+++ b/treq/test/test_treq_integration.py
@@ -9,8 +9,9 @@ from twisted.internet.endpoints import TCP4ServerEndpoint
 from twisted.web.client import ResponseFailed
 
 from treq.auth import _RequestDigestAuthenticationAgent
-from treq.test.util import IntegrationTestCase, TestProxyFactory,\
-    TestProxyFactoryWithAuthentication, DEBUG, with_baseurl_and_proxy, is_pypy
+from treq.test.util import IntegrationTestCase, DEBUG
+from treq.test._proxyutil import TestProxyFactory,\
+    TestProxyFactoryWithAuthentication, with_baseurl_and_proxy
 
 import treq
 from treq.auth import HTTPDigestAuth

--- a/treq/test/test_treq_integration.py
+++ b/treq/test/test_treq_integration.py
@@ -320,7 +320,7 @@ class TreqProxyIntegrationTests(TreqIntegrationTests):
         yield super(TreqProxyIntegrationTests, self).test_timeout()
 
     @inlineCallbacks
-    def test_failing_proxy_auth(self):
+    def test_failed_proxy_auth(self):
         credentials = ('treq', 'treq')
         bad_credentials = ('not-treq', 'not-treq')
         yield self._set_up_proxy_with_authentication(credentials)

--- a/treq/test/util.py
+++ b/treq/test/util.py
@@ -1,15 +1,24 @@
 import os
+import re
+import base64
 import platform
+import urlparse
 
 import mock
 
 import twisted
 
 from twisted.internet import reactor
-from twisted.internet.task import Clock
+from twisted.internet.tcp import Client
+from twisted.internet.task import Clock, deferLater
+from twisted.web.proxy import Proxy, ProxyRequest
+from twisted.web.http import HTTPFactory
+from twisted.web.client import HTTPConnectionPool
 from twisted.trial.unittest import TestCase
 from twisted.python.failure import Failure
 from twisted.python.versions import Version
+
+import treq
 
 DEBUG = os.getenv("TREQ_DEBUG", False) == "true"
 
@@ -45,3 +54,174 @@ def with_clock(fn):
         with mock.patch.object(reactor, 'callLater', clock.callLater):
             return fn(*(args + (clock,)), **kwargs)
     return wrapper
+
+
+def with_baseurl(method):
+    def _request(self, url, *args, **kwargs):
+        return method(self.baseurl + url, *args, pool=self.pool, **kwargs)
+
+    return _request
+
+
+def with_baseurl_and_proxy(method):
+
+    def _request(self, url, *args, **kwargs):
+        kwargs.update({'proxy': self.proxy_params})
+        return method(self.baseurl + url, *args, pool=self.pool, **kwargs)
+
+    return _request
+
+
+class IntegrationTestCase(TestCase):
+
+    get = with_baseurl(treq.get)
+    head = with_baseurl(treq.head)
+    post = with_baseurl(treq.post)
+    put = with_baseurl(treq.put)
+    patch = with_baseurl(treq.patch)
+    delete = with_baseurl(treq.delete)
+
+    def setUp(self):
+        self.pool = HTTPConnectionPool(reactor, False)
+
+    def tearDown(self):
+        def _check_fds(_):
+            # This appears to only be necessary for HTTPS tests.
+            # For the normal HTTP tests then closeCachedConnections is
+            # sufficient.
+            fds = set(reactor.getReaders() + reactor.getReaders())
+            if not [fd for fd in fds if isinstance(fd, Client)]:
+                return
+
+            return deferLater(reactor, 0, _check_fds, None)
+
+        return self.pool.closeCachedConnections().addBoth(_check_fds)
+
+
+class TestProxyRequestFactory(ProxyRequest):
+
+    def process(self):
+        # We need to override this method since the original twisted.web.proxy
+        # lacks support of sending multiple header values
+        parsed = urlparse.urlparse(self.uri)
+        protocol = parsed[0]
+        host = parsed[1]
+        port = self.ports[protocol]
+        if ':' in host:
+            host, port = host.split(':')
+            port = int(port)
+        rest = urlparse.urlunparse(('', '') + parsed[2:])
+        if not rest:
+            rest = rest + '/'
+        class_ = self.protocols[protocol]
+
+        # Here we go:
+
+        headers = {}
+        for k, v in self.requestHeaders.getAllRawHeaders():
+            if len(v) == 1:
+                headers[k.lower()] = v[0]
+            else:
+                headers[k.lower()] = ",".join(v)
+
+        if 'host' not in headers:
+            headers['host'] = host
+        self.content.seek(0, 0)
+        s = self.content.read()
+        clientFactory = class_(self.method, rest, self.clientproto, headers,
+                               s, self)
+        self.reactor.connectTCP(host, port, clientFactory)
+
+    def finish(self):
+        # We need to override this method to do the proper timeout testing,
+        # since twisted.web.proxy fires RuntimeError when receives response
+        # after Treq disconnection; this does not affect the library logic,
+        # but saves us from internal proxy errors
+        try:
+            return ProxyRequest.finish(self)
+        except RuntimeError:
+            pass
+
+
+class TestProxyProtocol(Proxy):
+
+    requestFactory = TestProxyRequestFactory
+
+
+class TestProxyFactory(HTTPFactory):
+
+    def buildProtocol(self, addr):
+        return TestProxyProtocol()
+
+
+class TestProxyRequestFactoryWithAuthentication(ProxyRequest):
+
+    def checkAuthCredentials(self, username, password, proxy_auth_header):
+        creds_serialized = re.sub(r'Basic ', '', proxy_auth_header)
+        return creds_serialized == base64.b64encode(
+            "%s:%s" % (username, password)
+        )
+
+    def process(self):
+        parsed = urlparse.urlparse(self.uri)
+        protocol = parsed[0]
+        host = parsed[1]
+        port = self.ports[protocol]
+        if ':' in host:
+            host, port = host.split(':')
+            port = int(port)
+        rest = urlparse.urlunparse(('', '') + parsed[2:])
+        if not rest:
+            rest = rest + '/'
+        class_ = self.protocols[protocol]
+
+        # Here we go:
+
+        headers = {}
+        for k, v in self.requestHeaders.getAllRawHeaders():
+            if len(v) == 1:
+                headers[k.lower()] = v[0]
+            else:
+                headers[k.lower()] = ",".join(v)
+
+        if 'host' not in headers:
+            headers['host'] = host
+
+        username, password = self.channel.credentials
+
+        if 'proxy-authorization' not in headers or not \
+            self.checkAuthCredentials(
+                username, password, headers['proxy-authorization']
+            ):
+            self.transport.write(
+                "bHTTP/1.1 407 Proxy Authentication Required\r\n\r\n"
+            )
+            self.transport.loseConnection()
+            return
+        else:
+            headers.pop('proxy-authorization')
+
+        self.content.seek(0, 0)
+        s = self.content.read()
+        clientFactory = class_(self.method, rest, self.clientproto, headers,
+                               s, self)
+        self.reactor.connectTCP(host, port, clientFactory)
+
+
+class TestProxyWithAuthentication(Proxy):
+
+    requestFactory = TestProxyRequestFactoryWithAuthentication
+
+    def __init__(self, credentials):
+        self.credentials = credentials
+        Proxy.__init__(self)
+
+
+class TestProxyFactoryWithAuthentication(HTTPFactory):
+
+    def __init__(self, credentials, *args, **kwargs):
+        self.credentials = credentials
+        HTTPFactory.__init__(self, *args, **kwargs)
+
+    def buildProtocol(self, addr):
+        return TestProxyWithAuthentication(self.credentials)

--- a/treq/test/util.py
+++ b/treq/test/util.py
@@ -1,18 +1,13 @@
 import os
-import re
-import base64
 import platform
-import urlparse
 
 import mock
-
 import twisted
 
 from twisted.internet import reactor
 from twisted.internet.tcp import Client
 from twisted.internet.task import Clock, deferLater
-from twisted.web.proxy import Proxy, ProxyRequest
-from twisted.web.http import HTTPFactory
+
 from twisted.web.client import HTTPConnectionPool
 from twisted.trial.unittest import TestCase
 from twisted.python.failure import Failure
@@ -63,15 +58,6 @@ def with_baseurl(method):
     return _request
 
 
-def with_baseurl_and_proxy(method):
-
-    def _request(self, url, *args, **kwargs):
-        kwargs.update({'proxy': self.proxy_params})
-        return method(self.baseurl + url, *args, pool=self.pool, **kwargs)
-
-    return _request
-
-
 class IntegrationTestCase(TestCase):
 
     get = with_baseurl(treq.get)
@@ -96,132 +82,3 @@ class IntegrationTestCase(TestCase):
             return deferLater(reactor, 0, _check_fds, None)
 
         return self.pool.closeCachedConnections().addBoth(_check_fds)
-
-
-class TestProxyRequestFactory(ProxyRequest):
-
-    def process(self):
-        # We need to override this method since the original twisted.web.proxy
-        # lacks support of sending multiple header values
-        parsed = urlparse.urlparse(self.uri)
-        protocol = parsed[0]
-        host = parsed[1]
-        port = self.ports[protocol]
-        if ':' in host:
-            host, port = host.split(':')
-            port = int(port)
-        rest = urlparse.urlunparse(('', '') + parsed[2:])
-        if not rest:
-            rest = rest + '/'
-        class_ = self.protocols[protocol]
-
-        # Here we go:
-
-        headers = {}
-        for k, v in self.requestHeaders.getAllRawHeaders():
-            if len(v) == 1:
-                headers[k.lower()] = v[0]
-            else:
-                headers[k.lower()] = ",".join(v)
-
-        if 'host' not in headers:
-            headers['host'] = host
-        self.content.seek(0, 0)
-        s = self.content.read()
-        clientFactory = class_(self.method, rest, self.clientproto, headers,
-                               s, self)
-        self.reactor.connectTCP(host, port, clientFactory)
-
-    def finish(self):
-        # We need to override this method to do the proper timeout testing,
-        # since twisted.web.proxy fires RuntimeError when receives response
-        # after Treq disconnection; this does not affect the library logic,
-        # but saves us from internal proxy errors
-        try:
-            return ProxyRequest.finish(self)
-        except RuntimeError:
-            pass
-
-
-class TestProxyProtocol(Proxy):
-
-    requestFactory = TestProxyRequestFactory
-
-
-class TestProxyFactory(HTTPFactory):
-
-    def buildProtocol(self, addr):
-        return TestProxyProtocol()
-
-
-class TestProxyRequestFactoryWithAuthentication(ProxyRequest):
-
-    def checkAuthCredentials(self, username, password, proxy_auth_header):
-        creds_serialized = re.sub(r'Basic ', '', proxy_auth_header)
-        return creds_serialized == base64.b64encode(
-            "%s:%s" % (username, password)
-        )
-
-    def process(self):
-        parsed = urlparse.urlparse(self.uri)
-        protocol = parsed[0]
-        host = parsed[1]
-        port = self.ports[protocol]
-        if ':' in host:
-            host, port = host.split(':')
-            port = int(port)
-        rest = urlparse.urlunparse(('', '') + parsed[2:])
-        if not rest:
-            rest = rest + '/'
-        class_ = self.protocols[protocol]
-
-        # Here we go:
-
-        headers = {}
-        for k, v in self.requestHeaders.getAllRawHeaders():
-            if len(v) == 1:
-                headers[k.lower()] = v[0]
-            else:
-                headers[k.lower()] = ",".join(v)
-
-        if 'host' not in headers:
-            headers['host'] = host
-
-        username, password = self.channel.credentials
-
-        if 'proxy-authorization' not in headers or not \
-            self.checkAuthCredentials(
-                username, password, headers['proxy-authorization']
-            ):
-            self.transport.write(
-                "bHTTP/1.1 407 Proxy Authentication Required\r\n\r\n"
-            )
-            self.transport.loseConnection()
-            return
-        else:
-            headers.pop('proxy-authorization')
-
-        self.content.seek(0, 0)
-        s = self.content.read()
-        clientFactory = class_(self.method, rest, self.clientproto, headers,
-                               s, self)
-        self.reactor.connectTCP(host, port, clientFactory)
-
-
-class TestProxyWithAuthentication(Proxy):
-
-    requestFactory = TestProxyRequestFactoryWithAuthentication
-
-    def __init__(self, credentials):
-        self.credentials = credentials
-        Proxy.__init__(self)
-
-
-class TestProxyFactoryWithAuthentication(HTTPFactory):
-
-    def __init__(self, credentials, *args, **kwargs):
-        self.credentials = credentials
-        HTTPFactory.__init__(self, *args, **kwargs)
-
-    def buildProtocol(self, addr):
-        return TestProxyWithAuthentication(self.credentials)


### PR DESCRIPTION
Added support for using HTTP proxies and Basic proxy authentication (without CONNECT method support). Digest auth stuff also goes to this pull; it is better to close my previous pull request and merge HTTP Digest support altogether with this pull, as i made some fixes to internal design of authentication API.