### PR TITLE
Fix requests dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@ pyflakes
 pep8
 sphinx
 mock
-requests
+requests>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     version=__version__,
     packages=find_packages(),
     install_requires=[
-        "Twisted >= 12.1.0", "requests", "service_identity", "pyOpenSSL >= 0.11"
+        "Twisted >= 12.1.0", "requests >= 2.1.0", "service_identity", "pyOpenSSL >= 0.11"
     ],
     package_data={"treq": ["_version"]},
     author="David Reid",


### PR DESCRIPTION
We use requests.cookies.merge_cookies, which is only present in requests >= 2.1.0