### PR TITLE
Update README.rst travis badge and add pypi badge.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,7 @@ treq
 ====
 
 |build|_
+|pypi|_
 
 ``treq`` is an HTTP library inspired by
 `requests <http://www.python-requests.org>`_ but written on top of
@@ -30,7 +31,7 @@ For more info `read the docs <http://treq.readthedocs.org>`_.
 Contribute
 ==========
 
-``treq`` is hosted on `GitHub <http://github.com/dreid/treq>`_.
+``treq`` is hosted on `GitHub <http://github.com/twisted/treq>`_.
 
 Feel free to fork and send contributions over.
 
@@ -68,5 +69,8 @@ Build docs:
 
     cd docs; make html
 
-.. |build| image:: https://secure.travis-ci.org/dreid/treq.png?branch=master
-.. _build: http://travis-ci.org/dreid/treq
+.. |build| image:: https://secure.travis-ci.org/twisted/treq.png?branch=master
+.. _build: http://travis-ci.org/twisted/treq
+
+.. |pypi| image:: http://img.shields.io/pypi/v/treq.png
+.. _pypi: https://pypi.python.org/pypi/treq


### PR DESCRIPTION
The previous badge url linked to the dreid/treq old repository (not present on travis).