### PR TITLE
Bump twisted requirement up to 13.2.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-Twisted>=12.1.0
+Twisted>=13.2.0
 pyflakes
 pep8
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     version=__version__,
     packages=find_packages(),
     install_requires=[
-        "Twisted >= 12.1.0", "requests >= 2.1.0", "service_identity", "pyOpenSSL >= 0.11"
+        "Twisted >= 13.2.0", "requests >= 2.1.0", "service_identity", "pyOpenSSL >= 0.11"
     ],
     package_data={"treq": ["_version"]},
     author="David Reid",


### PR DESCRIPTION
#101 removed Twisted < 13.2.0 from the test build matrix - since it's no longer tested, we should then probably require that Twisted be >= 13.2.0 in the setup and requirements file.