### PR TITLE
Dedup dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 htmlcov
 _trial_temp
 .tox
+_trial_temp.lock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
-Twisted>=13.2.0
+-e .
 pyflakes
 pep8
 sphinx
 mock
-requests>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,10 @@ setup(
     version=__version__,
     packages=find_packages(),
     install_requires=[
-        "Twisted >= 13.2.0", "requests >= 2.1.0", "service_identity", "pyOpenSSL >= 0.11"
+        "Twisted >= 13.2.0",
+        "pyOpenSSL",
+        "requests >= 2.1.0",
+        "service_identity",
     ],
     package_data={"treq": ["_version"]},
     author="David Reid",


### PR DESCRIPTION
Also remove the version requirement on pyOpenSSL because service_identity
requires 0.12 anyway.