### PR TITLE
Pin mock to 1.0.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@
 pyflakes
 pep8
 sphinx
-mock
+mock==1.0.1  # Can be removed once Python 2.6 is dropped.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = {pypy,py26,py27}-twisted_{13.2.0,14.0.0,15.0.0,15.1.0,15.2.1}-pyopenss
 [testenv]
 deps =
     coverage
-    mock
+    mock==1.0.1  # Can be removed once Python 2.6 is dropped.
     twisted_13.2.0: twisted==13.2.0
     twisted_14.0.0: twisted==14.0.0
     twisted_15.0.0: twisted==15.0.0


### PR DESCRIPTION
Newer versions do not support Python 2.6 which is breaking our tests: https://travis-ci.org/twisted/treq/jobs/70658274 e.g. in #96 