### PR TITLE
Small fixup to recent agent changes

### DIFF
--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -105,13 +105,13 @@ Full example: :download:`using_cookies.py <examples/using_cookies.py>`
 Agent Customization
 -------------------
 
-`treq` creates its own `twisted.web.client.Agent` with reasonable defaults, but
-you may want to provide your own custom agent.  A custom agent can be passed
-to the various `treq` request methods using the ``agent`` keyword argument.
+treq creates its own `twisted.web.client.Agent
+<https://twistedmatrix.com/documents/current/api/twisted.web.client.Agent.html>`_
+with reasonable defaults, but you may want to provide your own custom agent.
+A custom agent can be passed to the various treq request methods using the
+``agent`` keyword argument.
 
 .. code-block:: python
 
-    custom_agent = create_custom_agent(trusted_certs, timeout)
+    custom_agent = Agent(reactor, connectTimeout=42)
     treq.get(url, agent=custom_agent)
-
-

--- a/treq/api.py
+++ b/treq/api.py
@@ -106,10 +106,8 @@ def request(method, url, **kwargs):
 #
 
 def _client(*args, **kwargs):
-    agent = kwargs.get('agent', None)
-    if agent is not None:
-        del kwargs['agent']
-    else:
+    agent = kwargs.get('agent')
+    if agent is None:
         reactor = default_reactor(kwargs.get('reactor'))
         pool = default_pool(reactor,
                             kwargs.get('pool'),

--- a/treq/test/test_api.py
+++ b/treq/test/test_api.py
@@ -45,7 +45,9 @@ class TreqAPITests(TestCase):
         self.Agent.assert_called_with(mock.ANY, pool=pool)
 
     def test_custom_agent(self):
+        """
+        A custom Agent is used if specified.
+        """
         custom_agent = mock.Mock()
         treq.get('https://www.example.org/', agent=custom_agent)
         self.HTTPClient.assertCalledWith(custom_agent)
-


### PR DESCRIPTION
There was a small race condition between @glyph and me.  This PR should fix that. :)

- it links the Agent docs which should be useful if someone is reading about it
- show a more practical example instead of an opaque function
- simplify the agent logic.  kwargs isn’t used further down so no need to remove agent from it
- add a doc string to the test
- some whitespace fixes