### PR TITLE
No pypy for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,24 @@ notifications:
 # Don't fail on trunk versions.
 matrix:
   allow_failures:
+    - env: TOX_ENV=pypy-twisted_13.2.0-pyopenssl_0.13.1
+    - env: TOX_ENV=pypy-twisted_13.2.0-pyopenssl_0.14
+    - env: TOX_ENV=pypy-twisted_13.2.0-pyopenssl_0.15.1
+    - env: TOX_ENV=pypy-twisted_14.0.0-pyopenssl_0.13.1
+    - env: TOX_ENV=pypy-twisted_14.0.0-pyopenssl_0.14
+    - env: TOX_ENV=pypy-twisted_14.0.0-pyopenssl_0.15.1
+    - env: TOX_ENV=pypy-twisted_15.0.0-pyopenssl_0.13.1
+    - env: TOX_ENV=pypy-twisted_15.0.0-pyopenssl_0.14
+    - env: TOX_ENV=pypy-twisted_15.0.0-pyopenssl_0.15.1
+    - env: TOX_ENV=pypy-twisted_15.1.0-pyopenssl_0.13.1
+    - env: TOX_ENV=pypy-twisted_15.1.0-pyopenssl_0.14
+    - env: TOX_ENV=pypy-twisted_15.1.0-pyopenssl_0.15.1
+    - env: TOX_ENV=pypy-twisted_15.2.1-pyopenssl_0.13.1
+    - env: TOX_ENV=pypy-twisted_15.2.1-pyopenssl_0.14
+    - env: TOX_ENV=pypy-twisted_15.2.1-pyopenssl_0.15.1
     - env: TOX_ENV=pypy-twisted_trunk-pyopenssl_trunk
     - env: TOX_ENV=py27-twisted_trunk-pyopenssl_trunk
+
 
 branches:
   only:

--- a/tox2travis.py
+++ b/tox2travis.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Run like this:
+# tox -l | python tox2travis.py > .travis.yml
+
 from __future__ import absolute_import, print_function
 
 import sys

--- a/tox2travis.py
+++ b/tox2travis.py
@@ -37,8 +37,7 @@ notifications:
 # Don't fail on trunk versions.
 matrix:
   allow_failures:
-    - env: TOX_ENV=pypy-twisted_trunk-pyopenssl_trunk
-    - env: TOX_ENV=py27-twisted_trunk-pyopenssl_trunk
+    {allow_fails}
 
 branches:
   only:
@@ -54,6 +53,17 @@ if __name__ == "__main__":
         tox_envs.append(line)
         line = sys.stdin.readline()
 
+    allow_fail_features = [
+        "twisted_trunk",
+        "pyopenssl_trunk",
+        "pypy",
+    ]
     print(travis_template.format(
         envs='  '.join(
-            '- TOX_ENV={0}'.format(env) for env in tox_envs)))
+            '- TOX_ENV={0}'.format(env) for env in tox_envs),
+        allow_fails='    '.join(
+            '- env: TOX_ENV={0}'.format(env)
+            for env in tox_envs
+            if any(feature in env for feature in allow_fail_features)
+        )
+    ))


### PR DESCRIPTION
Right now Travis's infrastructure for testing pypy is somewhat broken, especially when combined with its caching infrastructure.  So disable testing for now and we'll re-enable it when travis upgrades to PyPy 2.6+.