### PR TITLE
add json support with "application/json" content-type to post method

### DIFF
--- a/treq/api.py
+++ b/treq/api.py
@@ -24,13 +24,13 @@ def get(url, headers=None, **kwargs):
     return _client(**kwargs).get(url, headers=headers, **kwargs)
 
 
-def post(url, data=None, **kwargs):
+def post(url, data=None, json=None, **kwargs):
     """
     Make a ``POST`` request.
 
     See :py:func:`treq.request`
     """
-    return _client(**kwargs).post(url, data=data, **kwargs)
+    return _client(**kwargs).post(url, data=data, json=json, **kwargs)
 
 
 def put(url, data=None, **kwargs):


### PR DESCRIPTION
Hello, first of all this is my first pull request ever tried/done so please forgive me if i do it wrong.

The Requests package provide 'json' keyword parameter to the post() method. It automatically set the content-type to 'application/json'
I have modified your code so that it is possible to pass a dict to the json keyword and it will be converted using json.dumps() and encoded in ascii
