### PR TITLE
Python 3: Decode JSON text as UTF-8 by default

### DIFF
--- a/treq/content.py
+++ b/treq/content.py
@@ -93,7 +93,8 @@ def json_content(response):
     :rtype: Deferred that fires with the decoded JSON.
     """
     if _PY3:
-        d = text_content(response)
+        # RFC4627: Default JSON text encoding is UTF-8
+        d = text_content(response, encoding='utf-8')
     else:
         d = content(response)
 

--- a/treq/content.py
+++ b/treq/content.py
@@ -93,7 +93,7 @@ def json_content(response):
     :rtype: Deferred that fires with the decoded JSON.
     """
     if _PY3:
-        # RFC4627: Default JSON text encoding is UTF-8
+        # RFC7159 (8.1): Default JSON character encoding is UTF-8
         d = text_content(response, encoding='utf-8')
     else:
         d = content(response)

--- a/treq/test/test_content.py
+++ b/treq/test/test_content.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import mock
 
 from twisted.python.failure import Failure
@@ -125,6 +126,21 @@ class ContentTests(TestCase):
         self.protocol.connectionLost(Failure(ResponseDone()))
 
         self.assertEqual(self.successResultOf(d), {"msg": "hello!"})
+
+    def test_json_content_unicode(self):
+        """
+        When Unicode JSON content is received, the JSON text should be
+        correctly decoded.
+        RFC4627: "JSON text shall be encoded in Unicode. The default encoding
+        is UTF-8."
+        """
+        self.response.headers = Headers()
+        d = json_content(self.response)
+
+        self.protocol.dataReceived(u'{"msg":"hëlló!"}'.encode('utf-8'))
+        self.protocol.connectionLost(Failure(ResponseDone()))
+
+        self.assertEqual(self.successResultOf(d), {u'msg': u'hëlló!'})
 
     def test_text_content(self):
         self.response.headers = Headers(

--- a/treq/test/test_content.py
+++ b/treq/test/test_content.py
@@ -131,8 +131,8 @@ class ContentTests(TestCase):
         """
         When Unicode JSON content is received, the JSON text should be
         correctly decoded.
-        RFC4627: "JSON text shall be encoded in Unicode. The default encoding
-        is UTF-8."
+        RFC7159 (8.1): "JSON text SHALL be encoded in UTF-8, UTF-16, or UTF-32.
+        The default encoding is UTF-8"
         """
         self.response.headers = Headers()
         d = json_content(self.response)


### PR DESCRIPTION
Default text encoding for JSON is UTF-8 not ISO-8859-1 like regular text content, as per [IETF RFC4627](http://www.ietf.org/rfc/rfc4627.txt).