### PR TITLE
Added HTTP proxy support to client.py

### DIFF
--- a/treq/client.py
+++ b/treq/client.py
@@ -166,6 +166,16 @@ class HTTPClient(object):
             bodyProducer = self._data_to_body_producer(data)
 
         cookies = kwargs.get('cookies', {})
+        
+        
+	proxy = kwargs.get('proxy')
+	
+	if proxy is not None:
+		proxy = proxy.split(":")
+		_host = proxy[0]
+		port = int(proxy[1])
+		endpoint = TCP4ClientEndpoint(reactor, _host, port)
+		self._agent = ProxyAgent(endpoint)
 
         if not isinstance(cookies, CookieJar):
             cookies = cookiejar_from_dict(cookies)

--- a/treq/client.py
+++ b/treq/client.py
@@ -174,7 +174,7 @@ class HTTPClient(object):
 		proxy = proxy.split(":")
 		_host = proxy[0]
 		port = int(proxy[1])
-		endpoint = TCP4ClientEndpoint(reactor, _host, port)
+		endpoint = TCP4ClientEndpoint(reactor, _host, port,timeout=10)
 		self._agent = ProxyAgent(endpoint)
 
         if not isinstance(cookies, CookieJar):

--- a/treq/client.py
+++ b/treq/client.py
@@ -174,7 +174,7 @@ class HTTPClient(object):
 		proxy = proxy.split(":")
 		_host = proxy[0]
 		port = int(proxy[1])
-		endpoint = TCP4ClientEndpoint(reactor, _host, port,timeout=10)
+		endpoint = TCP4ClientEndpoint(reactor, _host, port,timeout=5)
 		self._agent = ProxyAgent(endpoint)
 
         if not isinstance(cookies, CookieJar):


### PR DESCRIPTION
Added an optional proxy param for a request. To issue a request with an HTTP proxy simply include proxy= "ip:port" as an argument in the request call