### PR TITLE
Allow selection of RedirectAgent

### DIFF
--- a/treq/api.py
+++ b/treq/api.py
@@ -97,6 +97,8 @@ def request(method, url, **kwargs):
         received within this timeframe, a connection is aborted with
         ``CancelledError``.
 
+    :param bool browser_like_redirects: Use browser like redirects (i.e. Ignore  RFC2616 section 10.3 and follow redirects from POST requests).  Default: ``False``
+
     :rtype: Deferred that fires with an IResponse provider.
 
     """

--- a/treq/api.py
+++ b/treq/api.py
@@ -97,7 +97,9 @@ def request(method, url, **kwargs):
         received within this timeframe, a connection is aborted with
         ``CancelledError``.
 
-    :param bool browser_like_redirects: Use browser like redirects (i.e. Ignore  RFC2616 section 10.3 and follow redirects from POST requests).  Default: ``False``
+    :param bool browser_like_redirects: Use browser like redirects
+        (i.e. Ignore  RFC2616 section 10.3 and follow redirects from
+        POST requests).  Default: ``False``
 
     :rtype: Deferred that fires with an IResponse provider.
 

--- a/treq/client.py
+++ b/treq/client.py
@@ -13,14 +13,6 @@ from twisted.python.filepath import FilePath
 
 from twisted.web.http import urlparse
 
-if _PY3:
-    from urllib.parse import urlunparse, urlencode as _urlencode
-
-    def urlencode(query, doseq):
-        return _urlencode(query, doseq).encode('ascii')
-else:
-    from urlparse import urlunparse
-    from urllib import urlencode
 
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer, IResponse
@@ -40,13 +32,18 @@ from treq._utils import default_reactor
 from treq.auth import add_auth
 from treq import multipart
 from treq.response import _Response
+from requests.cookies import cookiejar_from_dict, merge_cookies
 
 if _PY3:
+    from urllib.parse import urlunparse, urlencode as _urlencode
+
+    def urlencode(query, doseq):
+        return _urlencode(query, doseq).encode('ascii')
     from http.cookiejar import CookieJar
 else:
     from cookielib import CookieJar
-
-from requests.cookies import cookiejar_from_dict, merge_cookies
+    from urlparse import urlunparse
+    from urllib import urlencode
 
 
 class _BodyBufferingProtocol(proxyForInterface(IProtocol)):

--- a/treq/client.py
+++ b/treq/client.py
@@ -28,6 +28,7 @@ from twisted.web.iweb import IBodyProducer, IResponse
 from twisted.web.client import (
     FileBodyProducer,
     RedirectAgent,
+    BrowserLikeRedirectAgent,
     ContentDecoderAgent,
     GzipDecoder,
     CookieAgent
@@ -205,7 +206,10 @@ class HTTPClient(object):
         wrapped_agent = CookieAgent(self._agent, cookies)
 
         if kwargs.get('allow_redirects', True):
-            wrapped_agent = RedirectAgent(wrapped_agent)
+            if kwargs.get("browser_like_redirects", False):
+                wrapped_agent = BrowserLikeRedirectAgent(wrapped_agent)
+            else:
+                wrapped_agent = RedirectAgent(wrapped_agent)
 
         wrapped_agent = ContentDecoderAgent(wrapped_agent,
                                             [(b'gzip', GzipDecoder)])

--- a/treq/client.py
+++ b/treq/client.py
@@ -206,7 +206,7 @@ class HTTPClient(object):
         wrapped_agent = CookieAgent(self._agent, cookies)
 
         if kwargs.get('allow_redirects', True):
-            if kwargs.get("browser_like_redirects", False):
+            if kwargs.get('browser_like_redirects', False):
                 wrapped_agent = BrowserLikeRedirectAgent(wrapped_agent)
             else:
                 wrapped_agent = RedirectAgent(wrapped_agent)


### PR DESCRIPTION
Unfortunately, not all servers and server software respect [RFC2616 section 10.3](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3). Some of them will send a redirect after a POST request, which raises an exception. 

This PR adds a keyword argument (`browser_like_redirects `) to `HTTPClient.request` to
allow selecting the `BrowserLikeRedirectAgent` instead of the regular
`RedirectAgent `