### PR TITLE
Mention, and emphasize, `HTTPClient` in the documentation

### DIFF
--- a/treq/api.py
+++ b/treq/api.py
@@ -108,9 +108,11 @@ def request(method, url, **kwargs):
 #
 
 def _client(*args, **kwargs):
-    reactor = default_reactor(kwargs.get('reactor'))
-    pool = default_pool(reactor,
-                        kwargs.get('pool'),
-                        kwargs.get('persistent'))
-    agent = Agent(reactor, pool=pool)
+    agent = kwargs.get('agent')
+    if agent is None:
+        reactor = default_reactor(kwargs.get('reactor'))
+        pool = default_pool(reactor,
+                            kwargs.get('pool'),
+                            kwargs.get('persistent'))
+        agent = Agent(reactor, pool=pool)
     return HTTPClient(agent)

--- a/treq/test/test_api.py
+++ b/treq/test/test_api.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division
 import mock
 
 from treq.test.util import TestCase
-
 import treq
 from treq._utils import set_global_pool
 


### PR DESCRIPTION
Rather than encouraging people to mess around with `agent=` in the treq signature.

This is a continuation of @cwaldbieser's work from #109 .
