### PR TITLE
use twisted, instead of pkg_resources, for version

### DIFF
--- a/treq/__init__.py
+++ b/treq/__init__.py
@@ -8,4 +8,6 @@ __all__ = ['head', 'get', 'post', 'put', 'patch', 'delete', 'request',
 
 from twisted.python.modules import getModule as _getModule
 
-__version__ = _getModule(__name__).filePath.sibling("_version").strip()
+__version__ = (
+    _getModule(__name__).filePath.sibling("_version").getContent().strip()
+)

--- a/treq/__init__.py
+++ b/treq/__init__.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-from pkg_resources import resource_string
-
 from treq.api import head, get, post, put, patch, delete, request
 from treq.content import collect, content, text_content, json_content
 
 __all__ = ['head', 'get', 'post', 'put', 'patch', 'delete', 'request',
            'collect', 'content', 'text_content', 'json_content']
 
-__version__ = resource_string(__name__, "_version").strip()
+from twisted.python.modules import getModule as _getModule
+
+__version__ = _getModule(__name__).filePath.sibling("_version").strip()

--- a/treq/__init__.py
+++ b/treq/__init__.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
+from twisted.python.modules import getModule as _getModule
+
 from treq.api import head, get, post, put, patch, delete, request
 from treq.content import collect, content, text_content, json_content
 
 __all__ = ['head', 'get', 'post', 'put', 'patch', 'delete', 'request',
            'collect', 'content', 'text_content', 'json_content']
-
-from twisted.python.modules import getModule as _getModule
 
 __version__ = (
     _getModule(__name__).filePath.sibling("_version").getContent().strip()


### PR DESCRIPTION
`pkg_resources` keeps causing weird packaging issues, like [this](https://travis-ci.org/rackerlabs/mimic/jobs/156439316).  This change is functionally identical, but uses `twisted.python.modules` instead.