### PR TITLE
Update build matrix to Twisted 16.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,36 +7,41 @@ python: 2.7
 cache: false
 
 env:
-  - TOX_ENV=pypy-twisted_14.0-pyopenssl_0.13.1
-  - TOX_ENV=pypy-twisted_14.0-pyopenssl_0.14
-  - TOX_ENV=pypy-twisted_14.0-pyopenssl_0.15.1
-  - TOX_ENV=pypy-twisted_15.1-pyopenssl_0.13.1
-  - TOX_ENV=pypy-twisted_15.1-pyopenssl_0.14
-  - TOX_ENV=pypy-twisted_15.1-pyopenssl_0.15.1
-  - TOX_ENV=pypy-twisted_15.3-pyopenssl_0.13.1
-  - TOX_ENV=pypy-twisted_15.3-pyopenssl_0.14
-  - TOX_ENV=pypy-twisted_15.3-pyopenssl_0.15.1
-  - TOX_ENV=pypy-twisted_15.5-pyopenssl_0.13.1
-  - TOX_ENV=pypy-twisted_15.5-pyopenssl_0.14
-  - TOX_ENV=pypy-twisted_15.5-pyopenssl_0.15.1
-  - TOX_ENV=py27-twisted_14.0-pyopenssl_0.13.1
-  - TOX_ENV=py27-twisted_14.0-pyopenssl_0.14
-  - TOX_ENV=py27-twisted_14.0-pyopenssl_0.15.1
-  - TOX_ENV=py27-twisted_15.1-pyopenssl_0.13.1
-  - TOX_ENV=py27-twisted_15.1-pyopenssl_0.14
-  - TOX_ENV=py27-twisted_15.1-pyopenssl_0.15.1
-  - TOX_ENV=py27-twisted_15.3-pyopenssl_0.13.1
-  - TOX_ENV=py27-twisted_15.3-pyopenssl_0.14
-  - TOX_ENV=py27-twisted_15.3-pyopenssl_0.15.1
-  - TOX_ENV=py27-twisted_15.5-pyopenssl_0.13.1
-  - TOX_ENV=py27-twisted_15.5-pyopenssl_0.14
-  - TOX_ENV=py27-twisted_15.5-pyopenssl_0.15.1
-  - TOX_ENV=py33-twisted_15.5-pyopenssl_0.15.1
-  - TOX_ENV=py34-twisted_15.5-pyopenssl_0.15.1
+  - TOX_ENV=pypy-twisted_16.0-pyopenssl_0.13.1
+  - TOX_ENV=pypy-twisted_16.0-pyopenssl_0.14
+  - TOX_ENV=pypy-twisted_16.0-pyopenssl_0.15.1
+  - TOX_ENV=pypy-twisted_16.1-pyopenssl_0.13.1
+  - TOX_ENV=pypy-twisted_16.1-pyopenssl_0.14
+  - TOX_ENV=pypy-twisted_16.1-pyopenssl_0.15.1
+  - TOX_ENV=pypy-twisted_16.2-pyopenssl_0.13.1
+  - TOX_ENV=pypy-twisted_16.2-pyopenssl_0.14
+  - TOX_ENV=pypy-twisted_16.2-pyopenssl_0.15.1
+  - TOX_ENV=pypy-twisted_16.3-pyopenssl_0.13.1
+  - TOX_ENV=pypy-twisted_16.3-pyopenssl_0.14
+  - TOX_ENV=pypy-twisted_16.3-pyopenssl_0.15.1
+  - TOX_ENV=pypy-twisted_16.4-pyopenssl_0.13.1
+  - TOX_ENV=pypy-twisted_16.4-pyopenssl_0.14
+  - TOX_ENV=pypy-twisted_16.4-pyopenssl_0.15.1
+  - TOX_ENV=py27-twisted_16.0-pyopenssl_0.13.1
+  - TOX_ENV=py27-twisted_16.0-pyopenssl_0.14
+  - TOX_ENV=py27-twisted_16.0-pyopenssl_0.15.1
+  - TOX_ENV=py27-twisted_16.1-pyopenssl_0.13.1
+  - TOX_ENV=py27-twisted_16.1-pyopenssl_0.14
+  - TOX_ENV=py27-twisted_16.1-pyopenssl_0.15.1
+  - TOX_ENV=py27-twisted_16.2-pyopenssl_0.13.1
+  - TOX_ENV=py27-twisted_16.2-pyopenssl_0.14
+  - TOX_ENV=py27-twisted_16.2-pyopenssl_0.15.1
+  - TOX_ENV=py27-twisted_16.3-pyopenssl_0.13.1
+  - TOX_ENV=py27-twisted_16.3-pyopenssl_0.14
+  - TOX_ENV=py27-twisted_16.3-pyopenssl_0.15.1
+  - TOX_ENV=py27-twisted_16.4-pyopenssl_0.13.1
+  - TOX_ENV=py27-twisted_16.4-pyopenssl_0.14
+  - TOX_ENV=py27-twisted_16.4-pyopenssl_0.15.1
   - TOX_ENV=pypy-twisted_trunk-pyopenssl_trunk
   - TOX_ENV=py27-twisted_trunk-pyopenssl_trunk
   - TOX_ENV=py33-twisted_trunk-pyopenssl_trunk
   - TOX_ENV=py34-twisted_trunk-pyopenssl_trunk
+  - TOX_ENV=py35-twisted_trunk-pyopenssl_trunk
   - TOX_ENV=pypi-readme
   - TOX_ENV=check-manifest
   - TOX_ENV=flake8
@@ -62,11 +67,6 @@ matrix:
     - env: TOX_ENV=py33-twisted_trunk-pyopenssl_trunk
     - env: TOX_ENV=py34-twisted_trunk-pyopenssl_trunk
     - env: TOX_ENV=py35-twisted_trunk-pyopenssl_trunk
-  include:
-    - python: 3.5
-      env: TOX_ENV=py35-twisted_15.5-pyopenssl_0.15.1
-    - python: 3.5
-      env: TOX_ENV=py35-twisted_trunk-pyopenssl_trunk
 
 branches:
   only:

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,10 @@ install_requires = [
 ]
 
 if PY3:
-    install_requires.append("Twisted >= 15.5.0")
+    install_requires.append("Twisted >= 16.0.0")
     install_requires.append("pyOpenSSL >= 0.15.1")
 else:
-    install_requires.append("Twisted >= 14.0.2")
+    install_requires.append("Twisted >= 16.0.0")
     install_requires.append("pyOpenSSL >= 0.13")
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-        {pypy,py27}-twisted_{14.0,15.1,15.3,15.5}-pyopenssl_{0.13.1,0.14,0.15.1},
-        {py33,py34,py35}-twisted_{15.5}-pyopenssl_{0.15.1},
+        {pypy,py27}-twisted_{16.0,16.1,16.2,16.3,16.4}-pyopenssl_{0.13.1,0.14,0.15.1},
         {pypy,py27,py33,py34,py35}-twisted_trunk-pyopenssl_trunk,
         pypi-readme, check-manifest, flake8
 
@@ -12,10 +11,10 @@ deps =
     ; Can't use Cryptography 1.0 on older PyPys
     pypy: cryptography<=0.9
 
-    twisted_14.0: twisted==14.0
-    twisted_15.1: twisted==15.1
-    twisted_15.3: twisted==15.3
-    twisted_15.5: twisted==15.5
+    twisted_16.0: twisted==16.0
+    twisted_16.1: twisted==16.1
+    twisted_16.3: twisted==16.3
+    twisted_16.4: twisted==16.4
     twisted_trunk: https://github.com/twisted/twisted/archive/trunk.zip
     pyopenssl_0.13.1: pyopenssl==0.13.1
     pyopenssl_0.14: pyopenssl==0.14


### PR DESCRIPTION
Pursuant to #120, upgrade the build matrix to Twisted 16.0+.