### PR TITLE
Allow custom authorization mechanisms.

### DIFF
--- a/docs/examples/custom_auth.py
+++ b/docs/examples/custom_auth.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+from twisted.internet.task import react
+from twisted.web.iweb import IAgent
+from _utils import print_response
+from zope.interface import implementer
+
+import treq
+
+
+@implementer(IAgent)
+class CustomAuth(object):
+    """
+    I implement a custom authorization scheme.
+    """
+
+    def __init__(self, agent):
+        self._agent = agent
+
+    def request(self, method, uri, headers=None, bodyProducer=None):
+        print("Some authorization occurs here")
+        return self._agent.request(method, uri, headers, bodyProducer)
+
+
+def main(reactor, *args):
+    d = treq.get(
+        'http://httpbin.org/get',
+        auth=CustomAuth,
+    )
+    d.addCallback(print_response)
+    return d
+
+react(main, [])

--- a/docs/examples/custom_auth.py
+++ b/docs/examples/custom_auth.py
@@ -10,7 +10,7 @@ from twisted.web.http import FORBIDDEN
 import treq
 
 
-class SillyAuthResource(Resource):
+class SillyAuthResource(Resource, object):
     """
     A resource that uses a silly, header-based authentication
     mechanism.

--- a/docs/examples/custom_auth.py
+++ b/docs/examples/custom_auth.py
@@ -1,32 +1,74 @@
 from __future__ import print_function
+from twisted.internet.endpoints import serverFromString
 from twisted.internet.task import react
-from twisted.web.iweb import IAgent
-from _utils import print_response
-from zope.interface import implementer
+from twisted.internet.defer import inlineCallbacks, maybeDeferred
+from twisted.web.resource import Resource
+from twisted.web.server import Site
+from twisted.web.http_headers import Headers
+from twisted.web.http import FORBIDDEN
 
 import treq
 
 
-@implementer(IAgent)
-class CustomAuth(object):
+class SillyAuthResource(Resource):
     """
-    I implement a custom authorization scheme.
+    A resource that uses a silly, header-based authentication
+    mechanism.
+    """
+    isLeaf = True
+
+    def __init__(self, header, secret):
+        self._header = header
+        self._secret = secret
+
+    def render_GET(self, request):
+        headers = request.requestHeaders
+        request_secret = headers.getRawHeaders(self._header, [b''])[0]
+        if request_secret != self._secret:
+            request.setResponseCode(FORBIDDEN)
+            return b"No good."
+        return b"It's good!"
+
+
+class SillyAuth(object):
+    """
+    I implement a silly, header-based authentication mechanism.
     """
 
-    def __init__(self, agent):
+    def __init__(self, header, secret, agent):
+        self._header = header
+        self._secret = secret
         self._agent = agent
 
     def request(self, method, uri, headers=None, bodyProducer=None):
-        print("Some authorization occurs here")
+        if headers is None:
+            headers = Headers({})
+        headers.setRawHeaders(self._header, [self._secret])
         return self._agent.request(method, uri, headers, bodyProducer)
 
 
+@inlineCallbacks
 def main(reactor, *args):
-    d = treq.get(
-        'http://httpbin.org/get',
-        auth=CustomAuth,
+    header = b'x-silly-auth'
+    secret = b'secret'
+
+    auth_resource = SillyAuthResource(header=header, secret=secret)
+
+    endpoint = serverFromString(reactor, "tcp:8080")
+    listener = yield endpoint.listen(Site(auth_resource))
+
+    def sillyAuthCallable(agent):
+        return SillyAuth(header, secret, agent)
+
+    response = yield treq.get(
+        'http://localhost:8080/',
+        auth=sillyAuthCallable,
     )
-    d.addCallback(print_response)
-    return d
+
+    content = yield response.content()
+    print(content)
+
+    yield maybeDeferred(listener.stopListening)
+
 
 react(main, [])

--- a/docs/examples/custom_auth.py
+++ b/docs/examples/custom_auth.py
@@ -10,9 +10,9 @@ from twisted.web.http import FORBIDDEN
 import treq
 
 
-class SillyAuthResource(Resource, object):
+class TrivialAuthResource(Resource, object):
     """
-    A resource that uses a silly, header-based authentication
+    A resource that uses a trivial, header-based authentication
     mechanism.
     """
     isLeaf = True
@@ -30,9 +30,9 @@ class SillyAuthResource(Resource, object):
         return b"It's good!"
 
 
-class SillyAuth(object):
+class TrivialAuth(object):
     """
-    I implement a silly, header-based authentication mechanism.
+    I implement a trivial, header-based authentication mechanism.
     """
 
     def __init__(self, header, secret, agent):
@@ -49,20 +49,20 @@ class SillyAuth(object):
 
 @inlineCallbacks
 def main(reactor, *args):
-    header = b'x-silly-auth'
+    header = b'x-trivial-auth'
     secret = b'secret'
 
-    auth_resource = SillyAuthResource(header=header, secret=secret)
+    auth_resource = TrivialAuthResource(header=header, secret=secret)
 
     endpoint = serverFromString(reactor, "tcp:8080")
     listener = yield endpoint.listen(Site(auth_resource))
 
-    def sillyAuthCallable(agent):
-        return SillyAuth(header, secret, agent)
+    def trivialAuthCallable(agent):
+        return TrivialAuth(header, secret, agent)
 
     response = yield treq.get(
         'http://localhost:8080/',
-        auth=sillyAuthCallable,
+        auth=trivialAuthCallable,
     )
 
     content = yield response.content()

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -54,6 +54,18 @@ Full example: :download:`basic_auth.py <examples/basic_auth.py>`
 
 .. _RFC 2617: http://www.ietf.org/rfc/rfc2617.txt
 
+The ``auth`` keyword argument also supports custom authorization
+implementations.  ``auth`` should be a callable that accepts as its
+only argument the currently configured ``IAgent`` and should return an
+``IAgent`` that implements the desired authorization mechanism.
+
+.. literalinclude:: examples/custom_auth.py
+    :linenos:
+    :lines: 10-33
+
+Full example: :download:`basic_auth.py <examples/custom_auth.py>`
+
+
 Redirects
 ---------
 

--- a/treq/auth.py
+++ b/treq/auth.py
@@ -37,5 +37,7 @@ def add_basic_auth(agent, username, password):
 def add_auth(agent, auth_config):
     if isinstance(auth_config, tuple):
         return add_basic_auth(agent, auth_config[0], auth_config[1])
+    elif callable(auth_config):
+        return auth_config(agent)
 
     raise UnknownAuthConfig(auth_config)


### PR DESCRIPTION
The auth keyword argument now takes a callable accepts an IAgent and
returns an IAgent.  The returned IAgent can then implement whatever
authorization scheme the human mind can imagine.
