### PR TITLE
Encode header values in treq.testing.HasHeaders

### DIFF
--- a/treq/test/test_testing.py
+++ b/treq/test/test_testing.py
@@ -294,6 +294,15 @@ class HasHeadersTests(TestCase):
         """
         self.assertNotEqual(HasHeaders({b'a': [b'a']}), {b'a': [b'A']})
 
+    def test_bytes_encoded_forms(self):
+        """
+        The :obj:`HasHeaders` equality function compares the bytes-encoded
+        forms of both sets of headers.
+        """
+        self.assertEqual(HasHeaders({b'a': [b'a']}), {u'a': [u'a']})
+
+        self.assertEqual(HasHeaders({u'b': [u'b']}), {b'b': [b'b']})
+
     def test_repr(self):
         """
         :obj:`HasHeaders` returns a nice string repr.

--- a/treq/testing.py
+++ b/treq/testing.py
@@ -291,8 +291,8 @@ def _maybeEncode(someStr):
 
 def _maybeEncodeHeaders(headers):
     """ Convert a headers mapping to its bytes-encoded form. """
-    return dict([(_maybeEncode(k).lower(), [_maybeEncode(v) for v in vs])
-                 for k, vs in headers.items()])
+    return {_maybeEncode(k).lower(): [_maybeEncode(v) for v in vs]
+            for k, vs in headers.items()}
 
 
 class HasHeaders(object):

--- a/treq/testing.py
+++ b/treq/testing.py
@@ -289,6 +289,12 @@ def _maybeEncode(someStr):
     return someStr
 
 
+def _maybeEncodeHeaders(headers):
+    """ Convert a headers mapping to its bytes-encoded form. """
+    return dict([(_maybeEncode(k).lower(), [_maybeEncode(v) for v in vs])
+                 for k, vs in headers.items()])
+
+
 class HasHeaders(object):
     """
     Since Twisted adds headers to a request, such as the host and the content
@@ -300,15 +306,13 @@ class HasHeaders(object):
     keys and values are compared in their bytes-encoded forms.
     """
     def __init__(self, headers):
-        self._headers = dict([(_maybeEncode(k).lower(), _maybeEncode(v))
-                              for k, v in headers.items()])
+        self._headers = _maybeEncodeHeaders(headers)
 
     def __repr__(self):
         return "HasHeaders({0})".format(repr(self._headers))
 
     def __eq__(self, other_headers):
-        compare_to = dict([(_maybeEncode(k).lower(), _maybeEncode(v))
-                           for k, v in other_headers.items()])
+        compare_to = _maybeEncodeHeaders(other_headers)
 
         return (set(self._headers.keys()).issubset(set(compare_to.keys())) and
                 all([set(v).issubset(set(compare_to[k]))

--- a/treq/testing.py
+++ b/treq/testing.py
@@ -304,6 +304,9 @@ class HasHeaders(object):
     This wraps a set of headers, and can be used in an equality test against
     a superset if the provided headers. The headers keys are lowercased, and
     keys and values are compared in their bytes-encoded forms.
+
+    Headers should be provided as a mapping from strings or bytes to a list of
+    strings or bytes.
     """
     def __init__(self, headers):
         self._headers = _maybeEncodeHeaders(headers)


### PR DESCRIPTION
Fixes #144.