### PR TITLE
Fix text_content with non-ASCII headers under Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _build
 build
 dist
 /docs/html
+/.eggs
 MANIFEST
 .coverage
 coverage

--- a/src/treq/content.py
+++ b/src/treq/content.py
@@ -9,11 +9,10 @@ from twisted.internet.defer import Deferred, succeed
 from twisted.internet.protocol import Protocol
 from twisted.web.client import ResponseDone
 from twisted.web.http import PotentialDataLoss
-from twisted.web.http_headers import Headers
 
 
 def _encoding_from_headers(headers):
-    content_types = headers.getRawHeaders('content-type')
+    content_types = headers.getRawHeaders(u'content-type')
     if content_types is None:
         return None
 
@@ -114,14 +113,7 @@ def text_content(response, encoding='ISO-8859-1'):
     """
     def _decode_content(c):
 
-        if _PY3:
-            headers = Headers({
-                key.decode('ascii'): [y.decode('ascii') for y in val]
-                for key, val in response.headers.getAllRawHeaders()})
-        else:
-            headers = response.headers
-
-        e = _encoding_from_headers(headers)
+        e = _encoding_from_headers(response.headers)
 
         if e is not None:
             return c.decode(e)

--- a/src/treq/content.py
+++ b/src/treq/content.py
@@ -107,9 +107,10 @@ def text_content(response, encoding='ISO-8859-1'):
     charset, which may be guessed from the ``Content-Type`` header.
 
     :param IResponse response: The HTTP Response to get the contents of.
-    :param str encoding: An valid charset, such as ``UTF-8`` or ``ISO-8859-1``.
+    :param str encoding: A charset, such as ``UTF-8`` or ``ISO-8859-1``,
+        used if the response does not specify an encoding.
 
-    :rtype: Deferred that fires with a unicode.
+    :rtype: Deferred that fires with a unicode string.
     """
     def _decode_content(c):
 

--- a/src/treq/content.py
+++ b/src/treq/content.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import cgi
 import json
 
-from twisted.python.compat import _PY3
 from twisted.internet.defer import Deferred, succeed
 
 from twisted.internet.protocol import Protocol
@@ -91,11 +90,8 @@ def json_content(response):
 
     :rtype: Deferred that fires with the decoded JSON.
     """
-    if _PY3:
-        # RFC7159 (8.1): Default JSON character encoding is UTF-8
-        d = text_content(response, encoding='utf-8')
-    else:
-        d = content(response)
+    # RFC7159 (8.1): Default JSON character encoding is UTF-8
+    d = text_content(response, encoding='utf-8')
 
     d.addCallback(json.loads)
     return d

--- a/src/treq/test/test_content.py
+++ b/src/treq/test/test_content.py
@@ -173,3 +173,19 @@ class ContentTests(TestCase):
         self.protocol.connectionLost(Failure(ResponseDone()))
 
         self.assertEqual(self.successResultOf(d), u'\xa1')
+
+    def test_text_content_unicode_headers(self):
+        """
+        Header parsing is robust against unicode header names and values.
+        """
+        self.response.headers = Headers({
+            b'Content-Type': [u'text/plain; charset="UTF-16BE"; u=ᛃ'.encode('utf-8')],
+            u'Coördination'.encode('iso-8859-1'): [u'koʊˌɔrdɪˈneɪʃən'.encode('utf-8')],
+        })
+
+        d = text_content(self.response)
+
+        self.protocol.dataReceived(u'ᚠᚡ'.encode('UTF-16BE'))
+        self.protocol.connectionLost(Failure(ResponseDone()))
+
+        self.assertEqual(self.successResultOf(d), u'ᚠᚡ')

--- a/src/treq/test/test_content.py
+++ b/src/treq/test/test_content.py
@@ -190,8 +190,10 @@ class ContentTests(TestCase):
         Header parsing is robust against unicode header names and values.
         """
         self.response.headers = Headers({
-            b'Content-Type': [u'text/plain; charset="UTF-16BE"; u=ᛃ'.encode('utf-8')],
-            u'Coördination'.encode('iso-8859-1'): [u'koʊˌɔrdɪˈneɪʃən'.encode('utf-8')],
+            b'Content-Type': [
+                u'text/plain; charset="UTF-16BE"; u=ᛃ'.encode('utf-8')],
+            u'Coördination'.encode('iso-8859-1'): [
+                u'koʊˌɔrdɪˈneɪʃən'.encode('utf-8')],
         })
 
         d = text_content(self.response)

--- a/src/treq/test/test_content.py
+++ b/src/treq/test/test_content.py
@@ -142,6 +142,17 @@ class ContentTests(TestCase):
 
         self.assertEqual(self.successResultOf(d), {u'msg': u'hëlló!'})
 
+    def test_json_content_utf16(self):
+        self.response.headers = Headers({
+            b'Content-Type': [b"application/json; charset='UTF-16LE'"],
+        })
+        d = json_content(self.response)
+
+        self.protocol.dataReceived(u'{"msg":"hëlló!"}'.encode('UTF-16LE'))
+        self.protocol.connectionLost(Failure(ResponseDone()))
+
+        self.assertEqual(self.successResultOf(d), {u'msg': u'hëlló!'})
+
     def test_text_content(self):
         self.response.headers = Headers(
             {b'Content-Type': [b'text/plain; charset=utf-8']})

--- a/src/treq/test/test_content.py
+++ b/src/treq/test/test_content.py
@@ -143,6 +143,10 @@ class ContentTests(TestCase):
         self.assertEqual(self.successResultOf(d), {u'msg': u'hëlló!'})
 
     def test_json_content_utf16(self):
+        """
+        JSON received is decoded according to the charset given in the
+        Content-Type header.
+        """
         self.response.headers = Headers({
             b'Content-Type': [b"application/json; charset='UTF-16LE'"],
         })


### PR DESCRIPTION
Fix for #148.