### PR TITLE
Update examples to work on Python 3

### DIFF
--- a/docs/examples/basic_post.py
+++ b/docs/examples/basic_post.py
@@ -8,8 +8,8 @@ import treq
 
 def main(reactor, *args):
     d = treq.post('http://httpbin.org/post',
-                  json.dumps({"msg": "Hello!"}),
-                  headers={'Content-Type': ['application/json']})
+                  json.dumps({"msg": "Hello!"}).encode('ascii'),
+                  headers={b'Content-Type': [b'application/json']})
     d.addCallback(print_response)
     return d
 

--- a/docs/examples/download_file.py
+++ b/docs/examples/download_file.py
@@ -4,7 +4,7 @@ import treq
 
 
 def download_file(reactor, url, destination_filename):
-    destination = file(destination_filename, 'w')
+    destination = open(destination_filename, 'wb')
     d = treq.get(url)
     d.addCallback(treq.collect, destination.write)
     d.addBoth(lambda _: destination.close())

--- a/docs/examples/query_params.py
+++ b/docs/examples/query_params.py
@@ -6,34 +6,34 @@ import treq
 
 @inlineCallbacks
 def main(reactor):
-    print 'List of tuples'
+    print('List of tuples')
     resp = yield treq.get('http://httpbin.org/get',
                           params=[('foo', 'bar'), ('baz', 'bax')])
-    content = yield treq.content(resp)
-    print content
+    content = yield resp.text()
+    print(content)
 
-    print 'Single value dictionary'
+    print('Single value dictionary')
     resp = yield treq.get('http://httpbin.org/get',
                           params={'foo': 'bar', 'baz': 'bax'})
-    content = yield treq.content(resp)
-    print content
+    content = yield resp.text()
+    print(content)
 
-    print 'Multi value dictionary'
+    print('Multi value dictionary')
     resp = yield treq.get('http://httpbin.org/get',
                           params={'foo': ['bar', 'baz', 'bax']})
-    content = yield treq.content(resp)
-    print content
+    content = yield resp.text()
+    print(content)
 
-    print 'Mixed value dictionary'
+    print('Mixed value dictionary')
     resp = yield treq.get('http://httpbin.org/get',
                           params={'foo': ['bar', 'baz'], 'bax': 'quux'})
-    content = yield treq.content(resp)
-    print content
+    content = yield resp.text()
+    print(content)
 
-    print 'Preserved query parameters'
+    print('Preserved query parameters')
     resp = yield treq.get('http://httpbin.org/get?foo=bar',
                           params={'baz': 'bax'})
-    content = yield treq.content(resp)
-    print content
+    content = yield resp.text()
+    print(content)
 
 react(main, [])

--- a/docs/examples/response_history.py
+++ b/docs/examples/response_history.py
@@ -8,7 +8,8 @@ def main(reactor, *args):
     d = treq.get('http://httpbin.org/redirect/1')
 
     def cb(response):
-        print 'Response history:', response.history()
+        print('Response history:')
+        print(response.history())
         return print_response(response)
 
     d.addCallback(cb)

--- a/docs/examples/using_cookies.py
+++ b/docs/examples/using_cookies.py
@@ -10,7 +10,7 @@ def main(reactor, *args):
     def _get_jar(resp):
         jar = resp.cookies()
 
-        print 'The server set our hello cookie to: {0}'.format(jar['hello'])
+        print('The server set our hello cookie to: {}'.format(jar['hello']))
 
         return treq.get('http://httpbin.org/cookies', cookies=jar)
 


### PR DESCRIPTION
As pointed out in #151 the basic_post.py example didn't work in Python 3. This also updates the others to be source compatible.