### PR TITLE
Tox: Use readme_renderer instead of readme

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands = flake8 src/treq/
 
 [testenv:pypi-readme]
 deps =
-    readme
+    readme_renderer
 commands =
     python setup.py check -r -s
 


### PR DESCRIPTION
According to the readme PyPI page[1] the readme_renderer distribution should be used instead.

[1]: https://pypi.python.org/pypi/readme