### PR TITLE
Dependency cleanup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,3 @@
 [bdist_wheel]
 # use py2.py3 tag for pure-python dist:
 universal=1
-
-[metadata]
-requires-dist =
-    pyOpenSSL >= 0.15.1; python_version > '3.0'
-    pyOpenSSL >= 0.13; python_version < '3.0'
-    requests >= 2.1.0
-    service_identity >=14.0.0
-    Twisted >= 15.5.0; python_version > '3.0'
-    Twisted >= 14.0.2; python_version < '3.0'

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,9 @@ setup(
         "requests >= 2.1.0",
         "six",
         "Twisted[tls] >= 16.0.0",
+        # Twisted[tls] 16.0.0 only requires 0.13, which doesn't work on Py3.
+        "pyOpenSSL >= 0.15.1",
     ],
-    extras_require={
-        ':python_version > "3.0"': ['pyOpenSSL >= 0.15.1'],
-    },
     package_data={"treq": ["_version"]},
     author="David Reid",
     author_email="dreid@dreid.org",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 from setuptools import find_packages, setup
 import os.path
-import sys
-
 
 with open(os.path.join(os.path.dirname(__file__), "treq", "_version")) as ver:
     __version__ = ver.readline().strip()
@@ -24,25 +22,18 @@ classifiers = [
 with open('README.rst') as f:
     readme = f.read()
 
-PY3 = (sys.version_info[0] >= 3)
-
-install_requires = [
-    "requests >= 2.1.0",
-    "service_identity >= 14.0.0",
-    "six",
-    "Twisted >= 16.0.0",
-]
-
-if PY3:
-    install_requires.append("pyOpenSSL >= 0.15.1")
-else:
-    install_requires.append("pyOpenSSL >= 0.13")
-
 setup(
     name="treq",
     version=__version__,
     packages=find_packages(),
-    install_requires=install_requires,
+    install_requires=[
+        "requests >= 2.1.0",
+        "six",
+        "Twisted[tls] >= 16.0.0",
+    ],
+    extras_require={
+        ':python_version > "3.0"': ['pyOpenSSL >= 0.15.1'],
+    },
     package_data={"treq": ["_version"]},
     author="David Reid",
     author_email="dreid@dreid.org",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "requests >= 2.1.0",
         "six",
         "Twisted[tls] >= 16.0.0",
-        # Twisted[tls] 16.0.0 only requires 0.13, which doesn't work on Py3.
+        # Twisted[tls] 16.0.0 requires 0.13, which doesn't work on Python 3.
         "pyOpenSSL >= 0.15.1",
     ],
     package_data={"treq": ["_version"]},

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
         "requests >= 2.1.0",
         "six",
         "Twisted[tls] >= 16.0.0",
+        # Twisted[tls] 16.0.0 doesn't specify a version.
+        "service_identity >= 14.0.0",
         # Twisted[tls] 16.0.0 requires 0.13, which doesn't work on Python 3.
         "pyOpenSSL >= 0.15.1",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,7 @@ deps =
     twisted_latest: Twisted
     twisted_trunk: https://github.com/twisted/twisted/archive/trunk.zip
 
-    {pypy,py27}-pyopenssl_lowest: pyOpenSSL==0.13
-    {py33,py34,py35}-pyopenssl_lowest: pyOpenSSL==0.15.1
+    {pypy,py27,py33,py34,py35}-pyopenssl_lowest: pyOpenSSL==0.15.1
     pyopenssl_latest: pyOpenSSL
     pyopenssl_trunk: https://github.com/pyca/pyopenssl/archive/master.zip
 passenv = TERM  # ensure colors


### PR DESCRIPTION
* Remove setup.cfg ``[metadata]`` section, which didn't match setup.py and [is deprecated anyway](https://wheel.readthedocs.io/en/latest/#defining-conditional-dependencies).
* Instead of depending on Twisted's various TLS dependencies directly, depend on Twisted[tls] which has been present since at least Twisted 16.0.0 (but retain a higher PyOpenSSL dep for Python 3, since ``Twisted[tls]`` requires a lesser version).