### PR TITLE
Use lower-case package name in Version

### DIFF
--- a/src/treq/_version.py
+++ b/src/treq/_version.py
@@ -1,11 +1,11 @@
 """
-Provides Treq version information.
+Provides treq version information.
 """
 
 # This file is auto-generated! Do not edit!
-# Use `python -m incremental.update Treq` to change this file.
+# Use `python -m incremental.update treq` to change this file.
 
 from incremental import Version
 
-__version__ = Version('Treq', 17, 3, 1)
+__version__ = Version('treq', 17, 3, 1)
 __all__ = ["__version__"]


### PR DESCRIPTION
This commit changes the name 'Treq' in _version.py to 'treq'. This makes the Version capitalization consistent with the caps throughout the package, and makes it possible to use `__version__.local()` to generate a local version number with incremental.