### PR TITLE
Implement fail_for_status

### DIFF
--- a/src/treq/__init__.py
+++ b/src/treq/__init__.py
@@ -4,8 +4,12 @@ from ._version import __version__
 
 from treq.api import head, get, post, put, patch, delete, request
 from treq.content import collect, content, text_content, json_content
+from treq.response import _Response
 
 __version__ = __version__.base()
 
+check_status = _Response.check_status
+
 __all__ = ['head', 'get', 'post', 'put', 'patch', 'delete', 'request',
-           'collect', 'content', 'text_content', 'json_content']
+           'check_status', 'collect', 'content', 'text_content',
+           'json_content']

--- a/src/treq/test/test_response.py
+++ b/src/treq/test/test_response.py
@@ -81,16 +81,6 @@ class ResponseTests(TestCase):
         wrapper = _Response(FakeResponse(200, Headers({})), None)
         self.assertEqual(wrapper.history(), [])
 
-    if skip_history:
-        test_history.skip = skip_history
-        test_no_history.skip = skip_history
-
-    def test_history_notimplemented(self):
-        wrapper = _Response(FakeResponse(200, Headers({})), None)
-        self.assertRaises(NotImplementedError, wrapper.history)
-
-    if not skip_history:
-        test_history_notimplemented.skip = "History supported."
 
     def test_check_status_ok(self):
         original = FakeResponse(200, Headers(), body=[b''])

--- a/src/treq/test/test_testing.py
+++ b/src/treq/test/test_testing.py
@@ -2,7 +2,7 @@
 In-memory treq returns stubbed responses.
 """
 from functools import partial
-from inspect import getmembers, isfunction
+from inspect import getmembers, isfunction, ismethod
 
 from mock import ANY
 
@@ -72,15 +72,19 @@ class StubbingTests(TestCase):
                       if obj.__module__ == "treq.api"]
         content_things = [(name, obj) for name, obj in treq_things
                           if obj.__module__ == "treq.content"]
+        response_things = [(name, obj) for name, obj in treq_things
+                           if obj.__module__ == "treq.response"]
 
         # sanity checks - this test should fail if treq exposes a new API
         # without changes being made to StubTreq and this test.
-        msg = ("At the time this test was written, StubTreq only knew about "
-               "treq exposing functions from treq.api and treq.content.  If "
-               "this has changed, StubTreq will need to be updated, as will "
-               "this test.")
-        self.assertTrue(all(isfunction(obj) for name, obj in treq_things), msg)
-        self.assertEqual(set(treq_things), set(api_things + content_things),
+        msg = ("StubTreq assumes that treq only exposes functions from "
+               "treq.api and treq.content, and treq.response.  If this has "
+               "changed, StubTreq will need to be updated, as will this "
+               "test.")
+        self.assertTrue(all((isfunction(obj) or ismethod(obj))
+                            for name, obj in treq_things), msg)
+        self.assertEqual(set(treq_things),
+                         set(api_things + content_things + response_things),
                          msg)
 
         for name, obj in api_things:


### PR DESCRIPTION
This commit adds a fail_for_status method to the Response object analogous to the 'raise_for_status' method in Request, to save users some time writing boilerplate status code checking.