### PR TITLE
Switch to a "dev" extra for dev requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst LICENSE tox.ini tox2travis.py requirements-dev.txt .coveragerc
+include README.rst LICENSE tox.ini tox2travis.py .coveragerc
 recursive-include docs *
 prune docs/_build
 exclude .travis.yml

--- a/README.rst
+++ b/README.rst
@@ -43,13 +43,7 @@ Install dependencies:
 
 ::
 
-    pip install -r requirements-dev.txt
-
-Optionally install PyOpenSSL:
-
-::
-
-    pip install PyOpenSSL
+    pip install treq[dev]
 
 Run Tests (unit & integration):
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,0 @@
--e .
-pyflakes
-pep8
-sphinx
-mock==1.0.1  # Can be removed once Python 2.6 is dropped.

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,14 @@ if __name__ == "__main__":
             # Twisted[tls] 16.0.0 requires 0.13, which doesn't work on Python 3.
             "pyOpenSSL >= 0.15.1",
         ],
+        extras_require={
+            "dev": [
+                "pyflakes",
+                "pep8",
+                "sphinx",
+                "mock==1.0.1",
+            ],
+        },
         package_data={"treq": ["_version"]},
         author="David Reid",
         author_email="dreid@dreid.org",

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ if __name__ == "__main__":
                 "pyflakes",
                 "pep8",
                 "sphinx",
+                # Can be removed once Python 2.6 is dropped.
                 "mock==1.0.1",
             ],
         },


### PR DESCRIPTION
Fixes #165 

In passing, I also removed the README directions for installing pyOpenSSL since it is already declared as a dependency and any `pip install treq` will bring it and its dependencies in.
