### PR TITLE
Avoid Twisted 17.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,10 @@ if __name__ == "__main__":
             "incremental",
             "requests >= 2.1.0",
             "six",
-            "Twisted[tls] >= 16.0.0",
+            # 17.1.0 is currently not compatible with RequestTraversalAgent
+            # See https://github.com/twisted/treq/issues/164
+            # And http://twistedmatrix.com/trac/ticket/9032
+            "Twisted[tls] >= 16.0.0, != 17.1.0",
             # Twisted[tls] 16.0.0 doesn't specify a version.
             "service_identity >= 14.0.0",
             # Twisted[tls] 16.0.0 requires 0.13, which doesn't work on Python 3.


### PR DESCRIPTION
This is a (presumably temporary) work-around for #164.

It will fix the build failures until the underlying problem with the implementation is addressed.