### PR TITLE
Fix the ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,5 @@
+python:
+  version: 2.7
+  pip_install: true
+  extra_requirements:
+    - dev

--- a/.rtd-requirements.txt
+++ b/.rtd-requirements.txt
@@ -1,5 +1,0 @@
-# This pip requirements file is used by the ReadTheDocs build to force
-# installation of treq to go through pip instead of `setup.py install`.
-# The latter command fails to install pyasn1[1].
-# [1]: https://readthedocs.org/projects/treq/builds/4906698/
--e .

--- a/.rtd-requirements.txt
+++ b/.rtd-requirements.txt
@@ -1,0 +1,5 @@
+# This pip requirements file is used by the ReadTheDocs build to force
+# installation of treq to go through pip instead of `setup.py install`.
+# The latter command fails to install pyasn1[1].
+# [1]: https://readthedocs.org/projects/treq/builds/4906698/
+-e .

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include README.rst LICENSE tox.ini tox2travis.py .coveragerc
 recursive-include docs *
 prune docs/_build
 exclude .travis.yml
+exclude .rtd-requirements.txt
 
 global-exclude .DS_Store *.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,6 @@ include README.rst LICENSE tox.ini tox2travis.py .coveragerc
 recursive-include docs *
 prune docs/_build
 exclude .travis.yml
-exclude .rtd-requirements.txt
+exclude .readthedocs.yml
 
 global-exclude .DS_Store *.pyc


### PR DESCRIPTION
The merge of #166 broke [the RTD build](https://readthedocs.org/projects/treq/builds/5040690/), where using a requirements file (so that the install goes through pip instead of setuptools) was the only way I could get it to correctly install pyasn1 (`python setup.py install` [got confused by pyasn1-modules](https://readthedocs.org/projects/treq/builds/4906698/)).