### PR TITLE
Narrative docs for treq.testing

### DIFF
--- a/docs/examples/iresource.py
+++ b/docs/examples/iresource.py
@@ -1,0 +1,16 @@
+import json
+
+from zope.interface import implementer
+from twisted.web.resource import IResource
+
+
+@implementer(IResource)
+class JsonResource(object):
+    isLeaf = True  # NB: means getChildWithDefault will not be called
+
+    def __init__(self, data):
+        self.data = data
+
+    def render(self, request):
+        request.setHeader(b'Content-Type', b'application/json')
+        return json.dumps(self.data).encode('utf-8')

--- a/docs/examples/testing_seq.py
+++ b/docs/examples/testing_seq.py
@@ -12,7 +12,7 @@ log = Logger()
 @defer.inlineCallbacks
 def make_a_request(treq):
     """
-    Make a few requests using treq.
+    Make a request using treq.
     """
     response = yield treq.get('http://an.example/foo', params={'a': 'b'},
                               headers={b'Accept': b'application/json'})

--- a/docs/examples/testing_seq.py
+++ b/docs/examples/testing_seq.py
@@ -1,0 +1,59 @@
+from twisted.internet import defer
+from twisted.logger import Logger
+from twisted.trial.unittest import SynchronousTestCase
+from twisted.web import http
+
+from treq.testing import StubTreq, HasHeaders
+from treq.testing import RequestSequence, StringStubbingResource
+
+log = Logger()
+
+
+@defer.inlineCallbacks
+def make_a_request(treq):
+    """
+    Make a few requests using treq.
+    """
+    response = yield treq.get('http://an.example/foo', params={'a': 'b'},
+                              headers={b'Accept': b'application/json'})
+    if response.code == http.OK:
+        result = yield response.json()
+    else:
+        message = yield response.text()
+        raise Exception("Got an error from the server: {}".format(message))
+    defer.returnValue(result)
+
+
+class MakeARequestTests(SynchronousTestCase):
+    """
+    Test :func:`make_a_request()` using :mod:`treq.testing.RequestSequence`.
+    """
+
+    def test_200_ok(self):
+        """On a 200 response, return the response's JSON."""
+        req_seq = RequestSequence([
+            ((b'get', b'http://an.example/foo', {b'a': [b'b']},
+              HasHeaders({'Accept': ['application/json']}), b''),
+             (http.OK, {b'Content-Type': b'application/json'}, b'{"status": "ok"}'))
+        ], log.error)
+        treq = StubTreq(StringStubbingResource(req_seq))
+
+        with req_seq.consume(self.fail):
+            result = self.successResultOf(make_a_request(treq))
+
+        self.assertEqual({"status": "ok"}, result)
+
+    def test_418_teapot(self):
+        """On an unexpected response code, raise an exception"""
+        req_seq = RequestSequence([
+            ((b'get', b'http://an.example/foo', {b'a': [b'b']},
+              HasHeaders({'Accept': ['application/json']}), b''),
+             (418, {b'Content-Type': b'text/plain'}, b"I'm a teapot!"))
+        ], log.error)
+        treq = StubTreq(StringStubbingResource(req_seq))
+
+        with req_seq.consume(self.fail):
+            failure = self.failureResultOf(make_a_request(treq))
+
+        self.assertEqual(u"Got an error from the server: I'm a teapot!",
+                         failure.getErrorMessage())

--- a/docs/examples/testing_seq.py
+++ b/docs/examples/testing_seq.py
@@ -32,7 +32,7 @@ class MakeARequestTests(SynchronousTestCase):
     def test_200_ok(self):
         """On a 200 response, return the response's JSON."""
         req_seq = RequestSequence([
-            ((b'get', b'http://an.example/foo', {b'a': [b'b']},
+            ((b'get', 'http://an.example/foo', {b'a': [b'b']},
               HasHeaders({'Accept': ['application/json']}), b''),
              (http.OK, {b'Content-Type': b'application/json'}, b'{"status": "ok"}'))
         ], log.error)
@@ -46,7 +46,7 @@ class MakeARequestTests(SynchronousTestCase):
     def test_418_teapot(self):
         """On an unexpected response code, raise an exception"""
         req_seq = RequestSequence([
-            ((b'get', b'http://an.example/foo', {b'a': [b'b']},
+            ((b'get', 'http://an.example/foo', {b'a': [b'b']},
               HasHeaders({'Accept': ['application/json']}), b''),
              (418, {b'Content-Type': b'text/plain'}, b"I'm a teapot!"))
         ], log.error)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,6 +99,7 @@ Table of Contents
     :maxdepth: 3
 
     howto
+    testing
     api
 
 Indices and tables

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,41 @@
+Testing Helpers
+===============
+
+The :mod:`treq.testing` module provides some tools for testing both HTTP clients which use the treq API and implementations of the `Twisted Web resource model <https://twistedmatrix.com/documents/current/api/twisted.web.resource.IResource.html>`.
+
+Writing tests for HTTP clients
+------------------------------
+
+The :class:`StubTreq` class implements the :mod:`treq` module interface (:func:`treq.get()`, :func:`treq.post()`, etc.) but runs all I/O via a :class:`~twisted.test.proto_helpers.MemoryReactor`.
+It wraps a :class:`twisted.web.resource.IResource` provider which handles each request.
+
+You can wrap a pre-existing `IResource` provider, or write your own.
+For example, the :class:`twisted.web.resource.ErrorPage` resource can produce an arbitrary HTTP status code.
+:class:`twisted.web.static.File` can serve files or directories.
+And you can easily achieve custom responses by writing trivial resources yourself:
+
+.. literalinclude:: examples/iresource.py
+    :linenos:
+    :pyobject: JsonResource
+
+However, those resources don't assert anything about the request.
+The :class:`~treq.testing.RequestSequence` and :class:`~treq.testing.StringStubbingResource` classes make it easy to construct a resource which encodes the expected request and response pairs.
+You may pass :class:`~treq.testing.HasHeaders` to make assertions about the headers present in the request.
+Do note that most parameters to these functions must be bytes—it's safest to use the ``b''`` string syntax, which works on both Python 2 and 3.
+
+For example:
+
+.. literalinclude:: examples/testing_seq.py
+    :linenos:
+
+This may be run with ``trial testing_seq.py``.
+Download: :download:`testing_seq.py <examples/testing_seq.py>`.
+
+Writing tests for Twisted Web resources
+---------------------------------------
+
+Since :class:`~treq.testing.StubTreq` wraps any resource, you can use it to test your server-side code as well.
+This is superior to calling your resource's methods directly or passing mock objects, since it uses a real :class:`~twisted.web.client.Agent` to generate the request and a real :class:`~twisted.web.server.Site` to process the response.
+Thus, the ``request`` object your code interacts with is a *real* :class:`twisted.web.server.Request` and behaves the same as it would in production.
+
+Note that if your resource returns :data:`~twisted.web.server.NOT_DONE` you must call the :class:`~treq.testing.StubTreq.flush()` method to spin the memory reactor once the server writes additional data before the client will receive it.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -54,4 +54,4 @@ Since :class:`~treq.testing.StubTreq` wraps any resource, you can use it to test
 This is superior to calling your resource's methods directly or passing mock objects, since it uses a real :class:`~twisted.web.client.Agent` to generate the request and a real :class:`~twisted.web.server.Site` to process the response.
 Thus, the ``request`` object your code interacts with is a *real* :class:`twisted.web.server.Request` and behaves the same as it would in production.
 
-Note that if your resource returns :data:`~twisted.web.server.NOT_DONE` you must call the :class:`~treq.testing.StubTreq.flush()` method to spin the memory reactor once the server writes additional data before the client will receive it.
+Note that if your resource returns :data:`~twisted.web.server.NOT_DONE_YET` you must call the :meth:`~treq.testing.StubTreq.flush()` method to spin the memory reactor once the server writes additional data before the client will receive it.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -20,7 +20,6 @@ And you can easily achieve custom responses by writing trivial resources yoursel
 
 However, those resources don't assert anything about the request.
 The :class:`~treq.testing.RequestSequence` and :class:`~treq.testing.StringStubbingResource` classes make it easy to construct a resource which encodes the expected request and response pairs.
-You may pass :class:`~treq.testing.HasHeaders` to make assertions about the headers present in the request.
 Do note that most parameters to these functions must be bytes—it's safest to use the ``b''`` string syntax, which works on both Python 2 and 3.
 
 For example:
@@ -30,6 +29,23 @@ For example:
 
 This may be run with ``trial testing_seq.py``.
 Download: :download:`testing_seq.py <examples/testing_seq.py>`.
+
+Loosely matching the request
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you don't care about certain parts of the request, you can pass :data:`mock.ANY`, which compares equal to anything.
+This sequence matches a single GET request with any parameters or headers:
+
+.. code-block:: python
+
+    RequestSequence([
+        ((b'get', mock.ANY, mock.ANY, b''), (200, {}, b'ok'))
+    ])
+
+
+If you care about headers, use :class:`~treq.testing.HasHeaders` to make assertions about the headers present in the request.
+It compares equal to a superset of the headers specified, which helps make your test robust to changes in treq or Agent.
+Right now treq adds the ``Accept-Encoding: gzip`` header, but as support for additional compression methods is added, this may change.
 
 Writing tests for Twisted Web resources
 ---------------------------------------

--- a/src/treq/test/test_testing.py
+++ b/src/treq/test/test_testing.py
@@ -409,6 +409,7 @@ class RequestSequenceTests(TestCase):
         d = stub.get('https://anything', data=b'what', headers={b'1': b'1'})
         resp = self.successResultOf(d)
         self.assertEqual(500, resp.code)
+        self.assertEqual(b'StubbingError', self.successResultOf(resp.content()))
         self.assertEqual(1, len(self.async_failures))
         self.assertIn("No more requests expected, but request",
                       self.async_failures[0])

--- a/src/treq/test/test_testing.py
+++ b/src/treq/test/test_testing.py
@@ -409,7 +409,8 @@ class RequestSequenceTests(TestCase):
         d = stub.get('https://anything', data=b'what', headers={b'1': b'1'})
         resp = self.successResultOf(d)
         self.assertEqual(500, resp.code)
-        self.assertEqual(b'StubbingError', self.successResultOf(resp.content()))
+        self.assertEqual(b'StubbingError',
+                         self.successResultOf(resp.content()))
         self.assertEqual(1, len(self.async_failures))
         self.assertIn("No more requests expected, but request",
                       self.async_failures[0])

--- a/src/treq/testing.py
+++ b/src/treq/testing.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 In-memory version of treq for testing.
 """
@@ -366,10 +367,12 @@ class RequestSequence(object):
     :ivar list sequence: The sequence of expected request arguments mapped to
         stubbed responses
     :ivar async_failure_reporter: A callable that takes a single message
-        reporting failures - it's asynchronous because it cannot just raise
-        an exception - if it does, :obj:`Resource.render` will just convert
+        reporting failures—it's asynchronous because it cannot just raise
+        an exception—if it does, :obj:`Resource.render` will just convert
         that into a 500 response, and there will be no other failure reporting
-        mechanism.
+        mechanism. Under Trial, this may be
+        a :class:`twisted.logger.Logger.error`, as Trial fails the test when an
+        error is logged.
     """
     def __init__(self, sequence, async_failure_reporter):
         self._sequence = sequence
@@ -388,11 +391,14 @@ class RequestSequence(object):
         """
         Usage::
 
-            sequence_stubs = RequestSequence([...])
+            async_failures = []
+            sequence_stubs = RequestSequence([...], async_failures.append)
             stub_treq = StubTreq(StringStubbingResource(sequence_stubs))
             with sequence_stubs.consume(self.fail):  # self = unittest.TestCase
                 stub_treq.get('http://fakeurl.com')
                 stub_treq.get('http://another-fake-url.com')
+
+            self.assertEqual([], async_failures)
 
         If there are still remaining expected requests to be made in the
         sequence, fails the provided test case.

--- a/src/treq/testing.py
+++ b/src/treq/testing.py
@@ -337,8 +337,8 @@ class RequestSequence(object):
          ...]
 
     Expects the requests to arrive in sequence order.  If there are no more
-    responses, or the request's parameters do not match the next item's expected
-    request parameters, raises :obj:`AssertionError`.
+    responses, or the request's parameters do not match the next item's
+    expected request parameters, raises :obj:`AssertionError`.
 
     For the expected request arguments:
 

--- a/src/treq/testing.py
+++ b/src/treq/testing.py
@@ -421,7 +421,7 @@ class RequestSequence(object):
             self._async_reporter(
                 "No more requests expected, but request {0!r} made.".format(
                     (method, url, params, headers, data)))
-            return (500, {}, "StubbingError")
+            return (500, {}, b"StubbingError")
 
         expected, response = self._sequence[0]
         e_method, e_url, e_params, e_headers, e_data = expected
@@ -441,7 +441,7 @@ class RequestSequence(object):
                 "\nMismatches: {2!r}"
                 .format(expected, (method, url, params, headers, data),
                         mismatches))
-            return (500, {}, "StubbingError")
+            return (500, {}, b"StubbingError")
 
         self._sequence = self._sequence[1:]
 

--- a/src/treq/testing.py
+++ b/src/treq/testing.py
@@ -219,7 +219,7 @@ class StringStubbingResource(Resource):
     The parameters for the callable are:
 
     - ``method``, the HTTP method as `bytes`.
-    - ``url``, the the full URL of the request as `bytes`.
+    - ``url``, the full URL of the request as text.
     - ``params``, a dictionary of query parameters mapping query keys
       lists of values (sorted alphabetically).
     - ``headers``, a dictionary of headers mapping header keys to
@@ -336,17 +336,17 @@ class RequestSequence(object):
          ...]
 
     Expects the requests to arrive in sequence order.  If there are no more
-    responses, or the request's paramters do not match the next item's expected
-    request paramters, raises :obj:`AssertionError`.
+    responses, or the request's parameters do not match the next item's expected
+    request parameters, raises :obj:`AssertionError`.
 
     For the expected request arguments:
 
     - ``method`` should be `bytes` normalized to lowercase.
-    - ``url`` should be normalized as per the transformations in
+    - ``url`` should be a `str` normalized as per the transformations in
       https://en.wikipedia.org/wiki/URL_normalization that (usually) preserve
-      semantics.  A url to `http://something-that-looks-like-a-directory`
+      semantics.  A URL to `http://something-that-looks-like-a-directory`
       would be normalized to `http://something-that-looks-like-a-directory/`
-      and a url to `http://something-that-looks-like-a-page/page.html`
+      and a URL to `http://something-that-looks-like-a-page/page.html`
       remains unchanged.
     - ``params`` is a dictionary mapping `bytes` to `lists` of `bytes`
     - ``headers`` is a dictionary mapping `bytes` to `lists` of `bytes` - note


### PR DESCRIPTION
This PR adds some narrative documentation of the `treq.testing` module based on my reading of the code and [experience](https://github.com/twm/yarrharr/commit/f2a853fb9f8e349e0c948d838d03697551cc0f36) [using](https://github.com/twm/yarrharr/commit/3fa6779ef67bc5125c8985aec0440eb39b9d5949) it.  I'd appreciate review and feedback, particularly from the original authors/reviews with respect to their intent and any limitations I haven't noted.