### PR TITLE
Reactor should not be imported when importing treq.

### DIFF
--- a/src/treq/_utils.py
+++ b/src/treq/_utils.py
@@ -4,8 +4,6 @@ Strictly internal utilities.
 
 from __future__ import absolute_import, division, print_function
 
-from twisted.web.client import HTTPConnectionPool
-
 
 def default_reactor(reactor):
     """
@@ -33,6 +31,7 @@ def default_pool(reactor, pool, persistent):
     Return the specified pool or a a pool with the specified reactor and
     persistence.
     """
+    from twisted.web.client import HTTPConnectionPool
     reactor = default_reactor(reactor)
 
     if pool is not None:

--- a/src/treq/api.py
+++ b/src/treq/api.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from twisted.web.client import Agent
-
-from treq.client import HTTPClient
 from treq._utils import default_pool, default_reactor
 
 
@@ -121,5 +118,8 @@ def _client(*args, **kwargs):
         pool = default_pool(reactor,
                             kwargs.get('pool'),
                             kwargs.get('persistent'))
+        from twisted.web.client import Agent
         agent = Agent(reactor, pool=pool)
+
+    from treq.client import HTTPClient
     return HTTPClient(agent)

--- a/src/treq/content.py
+++ b/src/treq/content.py
@@ -7,7 +7,6 @@ from twisted.python.compat import _PY3
 from twisted.internet.defer import Deferred, succeed
 
 from twisted.internet.protocol import Protocol
-from twisted.web.client import ResponseDone
 from twisted.web.http import PotentialDataLoss
 from twisted.web.http_headers import Headers
 
@@ -34,6 +33,7 @@ class _BodyCollector(Protocol):
         self.collector(data)
 
     def connectionLost(self, reason):
+        from twisted.web.client import ResponseDone
         if reason.check(ResponseDone):
             self.finished.callback(None)
         elif reason.check(PotentialDataLoss):

--- a/src/treq/test/test_import.py
+++ b/src/treq/test/test_import.py
@@ -1,0 +1,16 @@
+import sys
+import subprocess
+
+from treq.test.util import TestCase
+
+
+class TreqImportTests(TestCase):
+    def test_importing_treq_should_not_install_reactor(self):
+        # This test must be run under a new python process
+        # since treq.test.util has imported reactor already.
+        code = '\n'.join([
+            'import sys',
+            'import treq',
+            'sys.exit(int("twisted.internet.reactor" in sys.modules))',
+        ])
+        subprocess.check_call([sys.executable, '-c', code])


### PR DESCRIPTION
This fixes https://github.com/twisted/treq/issues/107 .

The problem is that `twisted.web.client` imports reactor at module level.
We can fix that by lazy import `twisted.web.client`.
