### PR TITLE
Eliminate pyOpenSSL dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,45 +8,25 @@ cache: pip
 matrix:
   include:
     - python: pypy
-      env: TOXENV=pypy-twisted_lowest-pyopenssl_lowest
+      env: TOXENV=pypy-twisted_lowest
     - python: pypy
-      env: TOXENV=pypy-twisted_lowest-pyopenssl_latest
-    - python: pypy
-      env: TOXENV=pypy-twisted_latest-pyopenssl_lowest
-    - python: pypy
-      env: TOXENV=pypy-twisted_latest-pyopenssl_latest
+      env: TOXENV=pypy-twisted_latest
     - python: '2.7'
-      env: TOXENV=py27-twisted_lowest-pyopenssl_lowest
+      env: TOXENV=py27-twisted_lowest
     - python: '2.7'
-      env: TOXENV=py27-twisted_lowest-pyopenssl_latest
-    - python: '2.7'
-      env: TOXENV=py27-twisted_latest-pyopenssl_lowest
-    - python: '2.7'
-      env: TOXENV=py27-twisted_latest-pyopenssl_latest
+      env: TOXENV=py27-twisted_latest
     - python: '3.3'
-      env: TOXENV=py33-twisted_lowest-pyopenssl_lowest
+      env: TOXENV=py33-twisted_lowest
     - python: '3.3'
-      env: TOXENV=py33-twisted_lowest-pyopenssl_latest
-    - python: '3.3'
-      env: TOXENV=py33-twisted_latest-pyopenssl_lowest
-    - python: '3.3'
-      env: TOXENV=py33-twisted_latest-pyopenssl_latest
+      env: TOXENV=py33-twisted_latest
     - python: '3.4'
-      env: TOXENV=py34-twisted_lowest-pyopenssl_lowest
+      env: TOXENV=py34-twisted_lowest
     - python: '3.4'
-      env: TOXENV=py34-twisted_lowest-pyopenssl_latest
-    - python: '3.4'
-      env: TOXENV=py34-twisted_latest-pyopenssl_lowest
-    - python: '3.4'
-      env: TOXENV=py34-twisted_latest-pyopenssl_latest
+      env: TOXENV=py34-twisted_latest
     - python: '3.5'
-      env: TOXENV=py35-twisted_lowest-pyopenssl_lowest
+      env: TOXENV=py35-twisted_lowest
     - python: '3.5'
-      env: TOXENV=py35-twisted_lowest-pyopenssl_latest
-    - python: '3.5'
-      env: TOXENV=py35-twisted_latest-pyopenssl_lowest
-    - python: '3.5'
-      env: TOXENV=py35-twisted_latest-pyopenssl_latest
+      env: TOXENV=py35-twisted_latest
     - python: pypy
       env: TOXENV=pypy-twisted_trunk-pyopenssl_trunk
     - python: '2.7'

--- a/setup.py
+++ b/setup.py
@@ -30,14 +30,7 @@ if __name__ == "__main__":
             "incremental",
             "requests >= 2.1.0",
             "six",
-            # 17.1.0 is currently not compatible with RequestTraversalAgent
-            # See https://github.com/twisted/treq/issues/164
-            # And http://twistedmatrix.com/trac/ticket/9032
-            "Twisted[tls] >= 16.0.0, != 17.1.0",
-            # Twisted[tls] 16.0.0 doesn't specify a version.
-            "service_identity >= 14.0.0",
-            # Twisted[tls] 16.0.0 requires 0.13, which doesn't work on Python 3.
-            "pyOpenSSL >= 0.15.1",
+            "Twisted[tls] >= 16.0.0",
         ],
         extras_require={
             "dev": [

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
             "incremental",
             "requests >= 2.1.0",
             "six",
-            "Twisted[tls] >= 16.0.0",
+            "Twisted[tls] >= 16.4.0, < 17.1.0",
         ],
         extras_require={
             "dev": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-        {pypy,py27,py33,py34,py35}-twisted_{lowest,latest}-pyopenssl_{lowest,latest},
+        {pypy,py27,py33,py34,py35}-twisted_{lowest,latest},
         {pypy,py27,py33,py34,py35}-twisted_trunk-pyopenssl_trunk,
         pypi-readme, check-manifest, flake8, docs
 
@@ -13,8 +13,6 @@ deps =
     twisted_latest: Twisted
     twisted_trunk: https://github.com/twisted/twisted/archive/trunk.zip
 
-    {pypy,py27,py33,py34,py35}-pyopenssl_lowest: pyOpenSSL==0.15.1
-    pyopenssl_latest: pyOpenSSL
     pyopenssl_trunk: https://github.com/pyca/pyopenssl/archive/master.zip
 
     docs: Sphinx>=1.4.8

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     coverage
     mock
 
-    twisted_lowest: Twisted==16.0
+    twisted_lowest: Twisted==16.4.0
     twisted_latest: Twisted
     twisted_trunk: https://github.com/twisted/twisted/archive/trunk.zip
 


### PR DESCRIPTION
As discussed in https://github.com/twisted/treq/pull/175#issuecomment-289319932 and the following comments, treq should depend on a version of Twisted that _itself_ depends on a Python 3 compatible version of pyOpenSSL.  This allows treq to completely eliminate its pyOpenSSL dependency and with it tox environments that test incompatible combinations of pyOpenSSL and Twisted.  These incompatible combinations prevent otherwise working PRs from building, like https://github.com/twisted/treq/pull/177.

@glyph points out that these tox environments' intent might have been to exercise treq-Twisted-pyOpenSSL combinations that occur when a user relies on a system-provided Twisted.  If that's the case, this PR might also need a documentation change that explains that installing from PyPI is the only officially supported means of acquiring treq.