### PR TITLE
Remove mention of dep versions from the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,7 @@
 treq: High-level Twisted HTTP Client API
 ========================================
 
-treq depends on Twisted 16.0.0 or later and optionally pyOpenSSL.
-It functions on Python 2.7 and Python 3.3+.
+`treq <https://pypi.python.org/pypi/treq>`_ depends on a recent Twisted and functions on Python 2.7 and Python 3.3+ (including PyPy).
 
 Why?
 ----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,8 +8,8 @@ Why?
 
 `requests`_ by `Kenneth Reitz`_ is a wonderful library.
 I want the same ease of use when writing Twisted applications.
-treq is not of course a perfect clone of `requests`.
-I have tried to stay true to the do-what-I-mean spirit of the `requests` API and also kept the API familiar to users of `Twisted`_ and :class:`twisted.web.client.Agent` on which treq is based.
+treq is not of course a perfect clone of `requests`_.
+I have tried to stay true to the do-what-I-mean spirit of the `requests`_ API and also kept the API familiar to users of `Twisted`_ and :class:`twisted.web.client.Agent` on which treq is based.
 
 .. _requests: http://python-requests.org/
 .. _Kenneth Reitz: https://www.gittip.com/kennethreitz/
@@ -44,7 +44,7 @@ Full example: :download:`basic_post.py <examples/basic_post.py>`
 Why not 100% requests-alike?
 ----------------------------
 
-Initially when I started off working on treq I thought the API should look exactly like `requests`_ except anything that would involve the network would return a `Deferred`.
+Initially when I started off working on treq I thought the API should look exactly like `requests`_ except anything that would involve the network would return a :class:`~twisted.internet.defer.Deferred`.
 
 Over time while attempting to mimic the `requests`_ API it became clear that not enough code could be shared between `requests`_ and treq for it to be worth the effort to translate many of the usage patterns from `requests`_.
 


### PR DESCRIPTION
As #178 shows, it's easy to miss updating the docs when changing setup.py.  Lacking an easy way to automate this, I think it's best to just delegate communication of this this information to PyPI.