### PR TITLE
Disable pip version check, virtualenv download

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,10 @@ deps =
     pyopenssl_trunk: https://github.com/pyca/pyopenssl/archive/master.zip
 
     docs: Sphinx>=1.4.8
+setenv =
+    # Avoid unnecessary network access when creating virtualenvs for speed.
+    VIRTUALENV_NO_DOWNLOAD=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 passenv = TERM  # ensure colors
 commands =
     pip list


### PR DESCRIPTION
In tox.ini:

* Set VIRTUALENV_NO_DOWNLOAD=1 so that virtualenv doesn't attempt to
  download the latest pip, setuptools, and wheel. Instead it uses the
  bundled wheels without hitting the network.
* Set PIP_DISABLE_VERSION_CHECK=1 so that pip doesn't hit the network
  to see if it's up to date.

This is a port of https://github.com/twisted/klein/pull/191