### PR TITLE
Add default async failure reporter to RequestSequence

### DIFF
--- a/docs/examples/testing_seq.py
+++ b/docs/examples/testing_seq.py
@@ -1,12 +1,9 @@
 from twisted.internet import defer
-from twisted.logger import Logger
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.web import http
 
 from treq.testing import StubTreq, HasHeaders
 from treq.testing import RequestSequence, StringStubbingResource
-
-log = Logger()
 
 
 @defer.inlineCallbacks
@@ -35,7 +32,7 @@ class MakeARequestTests(SynchronousTestCase):
             ((b'get', 'http://an.example/foo', {b'a': [b'b']},
               HasHeaders({'Accept': ['application/json']}), b''),
              (http.OK, {b'Content-Type': b'application/json'}, b'{"status": "ok"}'))
-        ], log.error)
+        ])
         treq = StubTreq(StringStubbingResource(req_seq))
 
         with req_seq.consume(self.fail):
@@ -49,7 +46,7 @@ class MakeARequestTests(SynchronousTestCase):
             ((b'get', 'http://an.example/foo', {b'a': [b'b']},
               HasHeaders({'Accept': ['application/json']}), b''),
              (418, {b'Content-Type': b'text/plain'}, b"I'm a teapot!"))
-        ], log.error)
+        ])
         treq = StubTreq(StringStubbingResource(req_seq))
 
         with req_seq.consume(self.fail):

--- a/src/treq/test/test_testing.py
+++ b/src/treq/test/test_testing.py
@@ -466,3 +466,17 @@ class RequestSequenceTests(TestCase):
 
         # no asynchronous failures (mismatches, etc.)
         self.assertEqual([], self.async_failures)
+
+    def test_async_failures_logged(self):
+        """
+        When no `async_failure_reporter` is passed async failures are logged by
+        default.
+        """
+        sequence = RequestSequence([])
+        stub = StubTreq(StringStubbingResource(sequence))
+
+        with sequence.consume(self.fail):
+            self.successResultOf(stub.get('https://example.com'))
+
+        [failure] = self.flushLoggedErrors()
+        self.assertIsInstance(failure.value, AssertionError)

--- a/src/treq/testing.py
+++ b/src/treq/testing.py
@@ -454,8 +454,11 @@ class RequestSequence(object):
         """
         # Passing message twice may look redundant, but Trial only preserves
         # the Failure, not the log message.
-        self._log.failure("RequestSequence async error: {message}", message=message,
-                          failure=Failure(AssertionError(message)))
+        self._log.failure(
+            "RequestSequence async error: {message}",
+            message=message,
+            failure=Failure(AssertionError(message)),
+        )
 
     def consumed(self):
         """
@@ -472,7 +475,8 @@ class RequestSequence(object):
 
             sequence_stubs = RequestSequence([...])
             stub_treq = StubTreq(StringStubbingResource(sequence_stubs))
-            with sequence_stubs.consume(self.fail):  # self = twisted.trial.unittest.TestCase
+            # self = twisted.trial.unittest.SynchronousTestCase
+            with sequence_stubs.consume(self.fail):
                 stub_treq.get('http://fakeurl.com')
                 stub_treq.get('http://another-fake-url.com')
 


### PR DESCRIPTION
Provide a default async failure reporter which, when not overridden, logs a match failure so that Trial knows to fail the test.

I also added some notes to the docs which relate to #205. Hopefully folks won't stub their toes too badly before the next Twisted release.

Closes #190