### PR TITLE
repr for augmented responses

### DIFF
--- a/src/treq/response.py
+++ b/src/treq/response.py
@@ -28,8 +28,10 @@ class _Response(proxyForInterface(IResponse)):
             size = 'unknown size'
         else:
             size = '{:,d} bytes'.format(self.original.length)
-        # Display non-ascii bits of the content-type header as backslash escapes.
-        content_type_bytes = b', '.join(self.original.headers.getRawHeaders(b'content-type', ()))
+        # Display non-ascii bits of the content-type header as backslash
+        # escapes.
+        content_type_bytes = b', '.join(
+            self.original.headers.getRawHeaders(b'content-type', ()))
         content_type = repr(content_type_bytes).lstrip('b')[1:-1]
         return "<{} {} '{:.40s}' {}>".format(
             reflect.qual(self.__class__),

--- a/src/treq/response.py
+++ b/src/treq/response.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 from twisted.python.components import proxyForInterface
-from twisted.web.iweb import IResponse
+from twisted.web.iweb import IResponse, UNKNOWN_LENGTH
+from twisted.python import reflect
 
 from requests.cookies import cookiejar_from_dict
 
@@ -17,6 +18,25 @@ class _Response(proxyForInterface(IResponse)):
     def __init__(self, original, cookiejar):
         self.original = original
         self._cookiejar = cookiejar
+
+    def __repr__(self):
+        """
+        Generate a representation of the response which includes the HTTP
+        status code, Content-Type header, and body size, if available.
+        """
+        if self.original.length == UNKNOWN_LENGTH:
+            size = 'unknown size'
+        else:
+            size = '{:,d} bytes'.format(self.original.length)
+        # Display non-ascii bits of the content-type header as backslash escapes.
+        content_type_bytes = b', '.join(self.original.headers.getRawHeaders(b'content-type', ()))
+        content_type = repr(content_type_bytes).lstrip('b')[1:-1]
+        return "<{} {} '{:.40s}' {}>".format(
+            reflect.qual(self.__class__),
+            self.original.code,
+            content_type,
+            size,
+        )
 
     def collect(self, collector):
         """

--- a/src/treq/test/test_response.py
+++ b/src/treq/test/test_response.py
@@ -2,6 +2,7 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from twisted.python.failure import Failure
 from twisted.web.client import ResponseDone
+from twisted.web.iweb import UNKNOWN_LENGTH
 from twisted.web.http_headers import Headers
 
 from treq.response import _Response
@@ -25,6 +26,51 @@ class FakeResponse(object):
 
 
 class ResponseTests(SynchronousTestCase):
+    def test_repr_content_type(self):
+        """
+        When the response has a Content-Type header its value is included in
+        the response.
+        """
+        headers = Headers({'Content-Type': ['text/html']})
+        original = FakeResponse(200, headers, body=[b'<!DOCTYPE html>'])
+        self.assertEqual(
+            "<treq.response._Response 200 'text/html' 15 bytes>",
+            repr(_Response(original, None)),
+        )
+
+    def test_repr_content_type_missing(self):
+        """
+        A request with no Content-Type just displays an empty field.
+        """
+        original = FakeResponse(204, Headers(), body=[b''])
+        self.assertEqual(
+            "<treq.response._Response 204 '' 0 bytes>",
+            repr(_Response(original, None)),
+        )
+
+    def test_repr_content_type_hostile(self):
+        """
+        Garbage in the Content-Type still produces a reasonable representation.
+        """
+        headers = Headers({'Content-Type': [u'\u2e18', ' x/y']})
+        original = FakeResponse(418, headers, body=[b''])
+        self.assertEqual(
+            r"<treq.response._Response 418 '\xe2\xb8\x98,  x/y' 0 bytes>",
+            repr(_Response(original, None)),
+        )
+
+    def test_repr_unknown_length(self):
+        """
+        A HTTP 1.0 or chunked response displays an unknown length.
+        """
+        headers = Headers({'Content-Type': ['text/event-stream']})
+        original = FakeResponse(200, headers)
+        original.length = UNKNOWN_LENGTH
+        self.assertEqual(
+            "<treq.response._Response 200 'text/event-stream' unknown size>",
+            repr(_Response(original, None)),
+        )
+
     def test_collect(self):
         original = FakeResponse(200, Headers(), body=[b'foo', b'bar', b'baz'])
         calls = []


### PR DESCRIPTION
Teach `treq.response._Response` to display itself like this:

```
>>> import treq
>>> r = treq.get('https://httpbin.org/bytes/1024')
>>> r.result
<treq.response._Response 200 'application/octet-stream' 1,024 bytes>
```

Closes #189.