### PR TITLE
Assume UTF-8 charset when application/json is set

### DIFF
--- a/src/treq/content.py
+++ b/src/treq/content.py
@@ -22,6 +22,9 @@ def _encoding_from_headers(headers):
     if 'charset' in params:
         return params.get('charset').strip("'\"")
 
+    if content_type == 'application/json':
+        return 'UTF-8'
+
 
 class _BodyCollector(Protocol):
     def __init__(self, finished, collector):

--- a/src/treq/test/test_content.py
+++ b/src/treq/test/test_content.py
@@ -188,6 +188,17 @@ class ContentTests(TestCase):
 
         self.assertEqual(self.successResultOf(d), u'\xa1')
 
+    def test_content_application_json_default_encoding(self):
+        self.response.headers = Headers(
+            {b'Content-Type': [b'application/json']})
+
+        d = text_content(self.response)
+
+        self.protocol.dataReceived(b'gr\xc3\xbcn')
+        self.protocol.connectionLost(Failure(ResponseDone()))
+
+        self.assertEqual(self.successResultOf(d), u'grün')
+
     def test_text_content_unicode_headers(self):
         """
         Header parsing is robust against unicode header names and values.


### PR DESCRIPTION
Per RFC-4627 content with type application/json must be encoded
in Unicode. So it is worth to return UTF-8 as an encoding charset
in such cases as a default.