### PR TITLE
Pin the httpbin version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
                 "pep8",
                 "pyflakes",
                 "sphinx",
-                "httpbin",
+                "httpbin==0.5.0",
             ],
         },
         package_data={"treq": ["_version"]},


### PR DESCRIPTION
`httpbin>=0.6.0`  breakes on pypy with `undefined symbol: _Py_ZeroStruct` error,
 which is being raised by the regex dependency