### PR TITLE
Python 3.3 requires enum34 to be installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ before_install:
       pyenv global pypy-5.4.1
     fi
   - pip install --upgrade pip
+  - pip install --upgrade setuptools
 
 install:
   - pip install tox codecov

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ if __name__ == "__main__":
             "attrs",
         ],
         extras_require={
+            "dev:(python_version < '3.4' and platform_python_implementation != 'PyPy')": ["enum34"],
             "dev": [
                 "mock",
                 "pep8",

--- a/tox2travis.py
+++ b/tox2travis.py
@@ -44,6 +44,7 @@ before_install:
       pyenv global pypy-5.4.1
     fi
   - pip install --upgrade pip
+  - pip install --upgrade setuptools
 
 install:
   - pip install tox codecov


### PR DESCRIPTION
Should fix [this](https://travis-ci.org/jameshilliard/treq/builds/294363299) test failure.