### PR TITLE
Fix agent customization sample code

### DIFF
--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -114,5 +114,13 @@ A custom agent can be passed to the various treq request methods using the
 .. code-block:: python
 
     custom_agent = Agent(reactor, connectTimeout=42)
+    treq.get(url, agent=custom_agent)
+
+Additionally a custom client can be instantiated to use a custom agent
+using the ``agent`` keyword argument:
+
+.. code-block:: python
+
+    custom_agent = Agent(reactor, connectTimeout=42)
     client = treq.client.HTTPClient(agent=custom_agent)
     client.get(url)

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -114,4 +114,5 @@ A custom agent can be passed to the various treq request methods using the
 .. code-block:: python
 
     custom_agent = Agent(reactor, connectTimeout=42)
-    treq.get(url, agent=custom_agent)
+    client = treq.client.HTTPClient(agent=custom_agent)
+    client.get(url)


### PR DESCRIPTION
This PR fixes a small issue in the documentation.

To be able to use a custom Agent, you need to instantiate `treq.client.HTTPClient` instead of passing it  on `treq.get()` kwargs