### PR TITLE
allow customization of loading json; pass params to loads()

### DIFF
--- a/src/treq/content.py
+++ b/src/treq/content.py
@@ -82,7 +82,7 @@ def content(response):
     return d
 
 
-def json_content(response, *args, **kwargs):
+def json_content(response, **kwargs):
     """
     Read the contents of an HTTP response and attempt to decode it as JSON.
 
@@ -91,8 +91,6 @@ def json_content(response, *args, **kwargs):
 
     :param IResponse response: The HTTP Response to get the contents of.
 
-    :param args: Any arguments accepted by :py:func:`json.loads`
-
     :param kwargs: Any keyword arguments accepted by :py:func:`json.loads`
 
     :rtype: Deferred that fires with the decoded JSON.
@@ -100,7 +98,7 @@ def json_content(response, *args, **kwargs):
     # RFC7159 (8.1): Default JSON character encoding is UTF-8
     d = text_content(response, encoding='utf-8')
 
-    d.addCallback(lambda text: json.loads(text, *args, **kwargs))
+    d.addCallback(lambda text: json.loads(text, **kwargs))
     return d
 
 

--- a/src/treq/content.py
+++ b/src/treq/content.py
@@ -82,7 +82,7 @@ def content(response):
     return d
 
 
-def json_content(response):
+def json_content(response, *args, **kwargs):
     """
     Read the contents of an HTTP response and attempt to decode it as JSON.
 
@@ -91,12 +91,16 @@ def json_content(response):
 
     :param IResponse response: The HTTP Response to get the contents of.
 
+    :param args: Any arguments accepted by :py:func:`json.loads`
+
+    :param kwargs: Any keyword arguments accepted by :py:func:`json.loads`
+
     :rtype: Deferred that fires with the decoded JSON.
     """
     # RFC7159 (8.1): Default JSON character encoding is UTF-8
     d = text_content(response, encoding='utf-8')
 
-    d.addCallback(json.loads)
+    d.addCallback(lambda text: json.loads(text, *args, **kwargs))
     return d
 
 

--- a/src/treq/response.py
+++ b/src/treq/response.py
@@ -62,14 +62,18 @@ class _Response(proxyForInterface(IResponse)):
         """
         return content(self.original)
 
-    def json(self):
+    def json(self, *args, **kwargs):
         """
         Collect the response body as JSON per :func:`treq.json_content()`.
+
+        :param args: Any arguments accepted by :py:func:`json.loads`
+
+        :param kwargs: Any keyword arguments accepted by :py:func:`json.loads`
 
         :rtype: Deferred that fires with the decoded JSON when the entire body
             has been read.
         """
-        return json_content(self.original)
+        return json_content(self.original, *args, **kwargs)
 
     def text(self, encoding='ISO-8859-1'):
         """

--- a/src/treq/response.py
+++ b/src/treq/response.py
@@ -62,18 +62,16 @@ class _Response(proxyForInterface(IResponse)):
         """
         return content(self.original)
 
-    def json(self, *args, **kwargs):
+    def json(self, **kwargs):
         """
         Collect the response body as JSON per :func:`treq.json_content()`.
-
-        :param args: Any arguments accepted by :py:func:`json.loads`
 
         :param kwargs: Any keyword arguments accepted by :py:func:`json.loads`
 
         :rtype: Deferred that fires with the decoded JSON when the entire body
             has been read.
         """
-        return json_content(self.original, *args, **kwargs)
+        return json_content(self.original, **kwargs)
 
     def text(self, encoding='ISO-8859-1'):
         """

--- a/src/treq/test/test_response.py
+++ b/src/treq/test/test_response.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from twisted.trial.unittest import SynchronousTestCase
 
 from twisted.python.failure import Failure
@@ -90,6 +92,16 @@ class ResponseTests(SynchronousTestCase):
             {'foo': 'bar'},
             self.successResultOf(_Response(original, None).json()),
         )
+
+    def test_json_customized(self):
+        original = FakeResponse(200, Headers(), body=[b'{"foo": ', b'1.0000000000000001}'])
+        self.assertEqual(
+            self.successResultOf(_Response(original, None).json(
+                parse_float=Decimal)
+            )["foo"],
+            Decimal("1.0000000000000001")
+        )
+
 
     def test_text(self):
         headers = Headers({b'content-type': [b'text/plain;charset=utf-8']})

--- a/src/treq/test/test_response.py
+++ b/src/treq/test/test_response.py
@@ -94,14 +94,14 @@ class ResponseTests(SynchronousTestCase):
         )
 
     def test_json_customized(self):
-        original = FakeResponse(200, Headers(), body=[b'{"foo": ', b'1.0000000000000001}'])
+        original = FakeResponse(200, Headers(), body=[b'{"foo": ',
+                                                      b'1.0000000000000001}'])
         self.assertEqual(
             self.successResultOf(_Response(original, None).json(
                 parse_float=Decimal)
             )["foo"],
             Decimal("1.0000000000000001")
         )
-
 
     def test_text(self):
         headers = Headers({b'content-type': [b'text/plain;charset=utf-8']})


### PR DESCRIPTION
Sometimes you need to be able to load a `Decimal` from a remote endpoint.