### PR TITLE
Add Python 3.7 support and enable testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ matrix:
     - env: TOXENV=py34-twisted_trunk-pyopenssl_trunk
     - env: TOXENV=py35-twisted_trunk-pyopenssl_trunk
     - env: TOXENV=py36-twisted_trunk-pyopenssl_trunk
+    - env: TOXENV=py37-twisted_trunk-pyopenssl_trunk
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,14 @@ matrix:
       env: TOXENV=py36-twisted_lowest
     - python: '3.6'
       env: TOXENV=py36-twisted_latest
+    - python: '3.7'
+      env: TOXENV=py37-twisted_lowest
+      dist: xenial
+      sudo: true
+    - python: '3.7'
+      env: TOXENV=py37-twisted_latest
+      dist: xenial
+      sudo: true
     - python: pypy
       env: TOXENV=pypy-twisted_trunk-pyopenssl_trunk
     - python: '2.7'
@@ -37,6 +45,10 @@ matrix:
       env: TOXENV=py35-twisted_trunk-pyopenssl_trunk
     - python: '3.6'
       env: TOXENV=py36-twisted_trunk-pyopenssl_trunk
+    - python: '3.7'
+      env: TOXENV=py37-twisted_trunk-pyopenssl_trunk
+      dist: xenial
+      sudo: true
     - python: '2.7'
       env: TOXENV=pypi-readme
     - python: '2.7'

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -29,7 +31,8 @@ if __name__ == "__main__":
             "incremental",
             "requests >= 2.1.0",
             "six",
-            "Twisted[tls] >= 16.4.0",
+            "Twisted[tls] >= 16.4.0 ; python_version < '3.7'",
+            "Twisted[tls] >= 18.7.0 ; python_version >= '3.7'",
             "attrs",
         ],
         extras_require={

--- a/src/treq/test/test_multipart.py
+++ b/src/treq/test/test_multipart.py
@@ -3,6 +3,7 @@
 # See LICENSE for details.
 
 import cgi
+import sys
 
 from io import BytesIO
 
@@ -594,9 +595,19 @@ my lovely bytes
             )
         )
 
-        form = cgi.parse_multipart(BytesIO(output), {"boundary": b"heyDavid"})
-        self.assertEqual(set([b'just a string\r\n', b'another string']),
-                         set(form['cfield']))
+        form = cgi.parse_multipart(BytesIO(output), {
+            "boundary": b"heyDavid",
+            "CONTENT-LENGTH": str(len(output)),
+        })
+
+        # Since Python 3.7, the value for a non-file field is now a list
+        # of strings, not bytes.
+        if sys.version_info >= (3, 7):
+            self.assertEqual(set(['just a string\r\n', 'another string']),
+                             set(form['cfield']))
+        else:
+            self.assertEqual(set([b'just a string\r\n', b'another string']),
+                             set(form['cfield']))
 
         self.assertEqual(set([b'my lovely bytes2']), set(form['efield']))
         self.assertEqual(set([b'my lovely bytes219']), set(form['xfield']))

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@ deps =
     coverage
     mock
 
-    twisted_lowest: Twisted==16.4.0
+    !py37-twisted_lowest: Twisted==16.4.0
+    py37-twisted_lowest: Twisted==18.7.0
     twisted_latest: Twisted
     twisted_trunk: https://github.com/twisted/twisted/archive/trunk.zip
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-        {pypy,py27,py34,py35,py36}-twisted_{lowest,latest},
-        {pypy,py27,py34,py35,py36}-twisted_trunk-pyopenssl_trunk,
+        {pypy,py27,py34,py35,py36,py37}-twisted_{lowest,latest},
+        {pypy,py27,py34,py35,py36,py37}-twisted_trunk-pyopenssl_trunk,
         pypi-readme, check-manifest, flake8, docs
 
 [testenv]

--- a/tox2travis.py
+++ b/tox2travis.py
@@ -27,11 +27,7 @@ matrix:
 
   # Don't fail on trunk versions.
   allow_failures:
-    - env: TOXENV=pypy-twisted_trunk-pyopenssl_trunk
-    - env: TOXENV=py27-twisted_trunk-pyopenssl_trunk
-    - env: TOXENV=py34-twisted_trunk-pyopenssl_trunk
-    - env: TOXENV=py35-twisted_trunk-pyopenssl_trunk
-    - env: TOXENV=py36-twisted_trunk-pyopenssl_trunk
+    {allow_failures}
 
 before_install:
   - |
@@ -81,6 +77,7 @@ if __name__ == "__main__":
         line = sys.stdin.readline()
 
     includes = []
+    allow_failures = []
     for tox_env in tox_envs:
         # Parse the Python version from the tox environment name
         python_match = re.match(r'^py(?:(\d{2})|py)-', tox_env)
@@ -106,4 +103,10 @@ if __name__ == "__main__":
                 '  sudo: true',
             ])
 
-    print(travis_template.format(includes='\n    '.join(includes)))
+        if 'trunk' in tox_env:
+            allow_failures.append('- env: TOXENV={0}'.format(tox_env))
+
+    print(travis_template.format(
+        allow_failures='\n    '.join(allow_failures),
+        includes='\n    '.join(includes),
+    ))

--- a/tox2travis.py
+++ b/tox2travis.py
@@ -98,4 +98,12 @@ if __name__ == "__main__":
             '  env: TOXENV={0}'.format(tox_env)
         ])
 
+        # Python 3.7 is available on sudo-enabled Xenial VMs only
+        # See https://github.com/travis-ci/travis-ci/issues/9815
+        if python == "'3.7'":
+            includes.extend([
+                '  dist: xenial',
+                '  sudo: true',
+            ])
+
     print(travis_template.format(includes='\n    '.join(includes)))


### PR DESCRIPTION
"CONTENT-LENGTH" is an undocumented new requirement in Python 3.7. I've asked upstream to clarify that - https://bugs.python.org/issue34226. There's a similar fix for twisted at https://github.com/twisted/twisted/commit/aa601a92de6a1e95f6525433f2e23a74040a93aa