### PR TITLE
examples: stream downloaded file without buffering

### DIFF
--- a/docs/examples/download_file.py
+++ b/docs/examples/download_file.py
@@ -5,7 +5,7 @@ import treq
 
 def download_file(reactor, url, destination_filename):
     destination = open(destination_filename, 'wb')
-    d = treq.get(url)
+    d = treq.get(url, unbuffered=True)
     d.addCallback(treq.collect, destination.write)
     d.addBoth(lambda _: destination.close())
     return d


### PR DESCRIPTION
Prior to this change, treq would buffer the entire file in memory, and Python's memory usage would rise to match the entire file size.