### PR TITLE
Correct RequestSequence response tuple type docs

### DIFF
--- a/src/treq/testing.py
+++ b/src/treq/testing.py
@@ -402,7 +402,7 @@ class RequestSequence(object):
 
     - ``code`` is an integer representing the HTTP status code to return.
     - ``headers`` is a dictionary mapping :class:`bytes` to :class:`bytes` or
-      :class:`list` of :class:`bytes`.
+      :class:`str`. Note that the value is *not* a list.
     - ``body`` is a :class:`bytes`.
 
     :ivar list sequence: A sequence of (request tuple, response tuple)


### PR DESCRIPTION
The header value is passed to [IRequest.setHeader()](https://twistedmatrix.com/documents/current/api/twisted.web.iweb.IRequest.html#setHeader) which accepts strings, not lists of strings.