### PR TITLE
Patch treq so public APIs don't swallow any unexpected kwargs.

### DIFF
--- a/src/treq/_utils.py
+++ b/src/treq/_utils.py
@@ -4,6 +4,9 @@ Strictly internal utilities.
 
 from __future__ import absolute_import, division, print_function
 
+import inspect
+import warnings
+
 from twisted.web.client import HTTPConnectionPool
 
 
@@ -45,3 +48,50 @@ def default_pool(reactor, pool, persistent):
         set_global_pool(HTTPConnectionPool(reactor, persistent=True))
 
     return get_global_pool()
+
+
+def warn(*args, **kwargs):
+    """
+    Utility function to raise warnings with stack level set automatically to
+    the first position outside a given namespace.
+
+    Notice that if you pass the stacklevel keyword, it will be increased by 1
+    in order to ignore this wrapper function and that will be passed directly
+    to warnings.warn. That is: it is functionally equivalent to warnings.warn.
+
+    @param namespace: calls within this namespace (aka startswith) will not
+        be accounted for in the stacklevel variable if possible.
+        If not defined, the default is the top level package of this code.
+    @param default_stacklevel: in those cases in which there is no code
+        outside of namespace in the stack, we will default to this value.
+        This utility function already takes into account the fact that it is a
+        wrapper around warnings.warn and secretly passes default_stacklevel+1
+        when necessary.
+        Defaults to 1, which would match the place where this was called from.
+    """
+    # Default to top-level package
+    namespace = kwargs.pop('namespace', __name__.partition('.')[0])
+    default_stacklevel = kwargs.pop('default_stacklevel', 1)
+    stacklevel = kwargs.pop('stacklevel', None)
+
+    if stacklevel is not None:
+        # Increase in order to ignore this wrapper function
+        # Users would not expect this function to count.
+        stacklevel += 1
+    else:
+        stack = inspect.stack()
+
+        # We skip the first stack frame in order to be able to use this
+        # utility function from other packages.
+        for current_stacklevel, frame_info in enumerate(stack[1:], 2):
+            module = inspect.getmodule(frame_info[0])
+            module_name = module.__name__ if module else None
+            if not (module_name and module_name.startswith(namespace + '.')):
+                break
+            stacklevel = current_stacklevel
+
+    if stacklevel is None:
+        stacklevel = default_stacklevel + 1
+    kwargs['stacklevel'] = stacklevel
+
+    warnings.warn(*args, **kwargs)

--- a/src/treq/api.py
+++ b/src/treq/api.py
@@ -12,7 +12,7 @@ def head(url, **kwargs):
 
     See :py:func:`treq.request`
     """
-    return _client(**kwargs).head(url, **kwargs)
+    return _client(kwargs).head(url, **kwargs)
 
 
 def get(url, headers=None, **kwargs):
@@ -21,7 +21,7 @@ def get(url, headers=None, **kwargs):
 
     See :py:func:`treq.request`
     """
-    return _client(**kwargs).get(url, headers=headers, **kwargs)
+    return _client(kwargs).get(url, headers=headers, **kwargs)
 
 
 def post(url, data=None, **kwargs):
@@ -30,7 +30,7 @@ def post(url, data=None, **kwargs):
 
     See :py:func:`treq.request`
     """
-    return _client(**kwargs).post(url, data=data, **kwargs)
+    return _client(kwargs).post(url, data=data, **kwargs)
 
 
 def put(url, data=None, **kwargs):
@@ -39,7 +39,7 @@ def put(url, data=None, **kwargs):
 
     See :py:func:`treq.request`
     """
-    return _client(**kwargs).put(url, data=data, **kwargs)
+    return _client(kwargs).put(url, data=data, **kwargs)
 
 
 def patch(url, data=None, **kwargs):
@@ -48,7 +48,7 @@ def patch(url, data=None, **kwargs):
 
     See :py:func:`treq.request`
     """
-    return _client(**kwargs).patch(url, data=data, **kwargs)
+    return _client(kwargs).patch(url, data=data, **kwargs)
 
 
 def delete(url, **kwargs):
@@ -57,7 +57,7 @@ def delete(url, **kwargs):
 
     See :py:func:`treq.request`
     """
-    return _client(**kwargs).delete(url, **kwargs)
+    return _client(kwargs).delete(url, **kwargs)
 
 
 def request(method, url, **kwargs):
@@ -80,6 +80,10 @@ def request(method, url, **kwargs):
 
     :param data: Optional request body.
     :type data: str, file-like, IBodyProducer, or None
+
+    :param files: If present, issue a ``multipart/form-data`` request as it
+        suits better for cases with filse and/or large objects.
+    :type files: list of (unicode, file-like) for (filename, file).
 
     :param json: Optional JSON-serializable content to pass in body.
     :type json: dict, list/tuple, int, string/unicode, bool, or None
@@ -116,19 +120,19 @@ def request(method, url, **kwargs):
     :rtype: Deferred that fires with an IResponse provider.
 
     """
-    return _client(**kwargs).request(method, url, **kwargs)
+    return _client(kwargs).request(method, url, **kwargs)
 
 
 #
 # Private API
 #
 
-def _client(*args, **kwargs):
-    agent = kwargs.get('agent')
+def _client(kwargs):
+    agent = kwargs.pop('agent', None)
+    pool = kwargs.pop('pool', None)
+    persistent = kwargs.pop('persistent', None)
     if agent is None:
         reactor = default_reactor(kwargs.get('reactor'))
-        pool = default_pool(reactor,
-                            kwargs.get('pool'),
-                            kwargs.get('persistent'))
+        pool = default_pool(reactor, pool, persistent)
         agent = Agent(reactor, pool=pool)
     return HTTPClient(agent)

--- a/src/treq/api.py
+++ b/src/treq/api.py
@@ -82,7 +82,7 @@ def request(method, url, **kwargs):
     :type data: str, file-like, IBodyProducer, or None
 
     :param files: If present, issue a ``multipart/form-data`` request as it
-        suits better for cases with filse and/or large objects.
+        is better suited for cases with files and/or large objects.
     :type files: list of (unicode, file-like) for (filename, file).
 
     :param json: Optional JSON-serializable content to pass in body.

--- a/src/treq/client.py
+++ b/src/treq/client.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import mimetypes
 import uuid
+import warnings
 
 from io import BytesIO
 
@@ -147,10 +148,20 @@ class HTTPClient(object):
                 headers=None, params=None, data=None, files=None,
                 auth=None, cookies=None, allow_redirects=True,
                 browser_like_redirects=False, unbuffered=False,
-                timeout=None, reactor=None, json=_NO_JSON):
+                timeout=None, reactor=None, json=_NO_JSON, **kwargs):
         """
         See :func:`treq.request()`.
         """
+        if kwargs:
+            warnings.warn("".join([
+                "treq.client.HttpClient.request will only accept ",
+                "supported documented arguments. ",
+                "This will raise an Exception in the future. ",
+                "Unsupported arguments: [",
+                ",".join(kwargs.keys()),
+                "]"]),
+                category=DeprecationWarning, stacklevel=2)
+
         method = method.encode('ascii').upper()
 
         # Join parameters provided in the URL

--- a/src/treq/client.py
+++ b/src/treq/client.py
@@ -217,11 +217,10 @@ class HTTPClient(object):
             json = json_dumps(json, separators=(u',', u':')).encode('utf-8')
             bodyProducer = self._data_to_body_producer(json)
 
-        if not isinstance(cookies, CookieJar):
-            cookies = cookiejar_from_dict(cookies)
-
-        cookies = merge_cookies(self._cookiejar, cookies)
-        wrapped_agent = CookieAgent(self._agent, cookies)
+        if cookies is not None:
+            # merge_cookies actually alters the CookieJar
+            merge_cookies(self._cookiejar, cookies)
+        wrapped_agent = CookieAgent(self._agent, self._cookiejar)
 
         if allow_redirects:
             if browser_like_redirects:

--- a/src/treq/client.py
+++ b/src/treq/client.py
@@ -196,7 +196,7 @@ class HTTPClient(object):
 
         if files:
             # If the files keyword is present we will issue a
-            # multipart/form-data request as it suits better for cases
+            # multipart/form-data request as it is better suited for cases
             # with files and/or large objects.
             files = list(_convert_files(files))
             boundary = str(uuid.uuid4()).encode('ascii')

--- a/src/treq/client.py
+++ b/src/treq/client.py
@@ -147,8 +147,8 @@ class HTTPClient(object):
         return self.request('DELETE', url, **kwargs)
 
     def request(self, method, url,
-                headers=None, params=None, data=None, files=list(),
-                auth=None, cookies=dict(), allow_redirects=True,
+                headers=None, params=None, data=None, files=None,
+                auth=None, cookies=None, allow_redirects=True,
                 browser_like_redirects=False, unbuffered=False,
                 timeout=None, reactor=None, json=_NoJsonData()):
         """

--- a/src/treq/client.py
+++ b/src/treq/client.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import mimetypes
 import uuid
-import warnings
 
 from io import BytesIO
 
@@ -30,7 +29,7 @@ from twisted.web.client import (
 from twisted.python.components import registerAdapter
 from json import dumps as json_dumps
 
-from treq._utils import default_reactor
+from treq._utils import default_reactor, warn
 from treq.auth import add_auth
 from treq import multipart
 from treq.response import _Response
@@ -153,14 +152,14 @@ class HTTPClient(object):
         See :func:`treq.request()`.
         """
         if kwargs:
-            warnings.warn("".join([
+            warn("".join([
                 "treq.client.HttpClient.request will only accept ",
                 "supported documented arguments. ",
                 "This will raise an Exception in the future. ",
                 "Unsupported arguments: [",
                 ",".join(kwargs.keys()),
                 "]"]),
-                category=DeprecationWarning, stacklevel=2)
+                category=DeprecationWarning, namespace='treq')
 
         method = method.encode('ascii').upper()
 

--- a/src/treq/client.py
+++ b/src/treq/client.py
@@ -98,9 +98,8 @@ class _BufferedResponse(proxyForInterface(IResponse)):
             self._waiters.append(protocol)
 
 
-class _NoJsonData():
-    """Dummy class to identify data that is not Json."""
-    pass
+# Dummy object to identify data that is not JSON.
+_NO_JSON = object()
 
 
 class HTTPClient(object):
@@ -150,7 +149,7 @@ class HTTPClient(object):
                 headers=None, params=None, data=None, files=None,
                 auth=None, cookies=None, allow_redirects=True,
                 browser_like_redirects=False, unbuffered=False,
-                timeout=None, reactor=None, json=_NoJsonData()):
+                timeout=None, reactor=None, json=_NO_JSON):
         """
         See :func:`treq.request()`.
         """
@@ -184,7 +183,7 @@ class HTTPClient(object):
         bodyProducer = None
         # since json=None needs to be serialized as 'null', we need to
         # perform a different kind of check.
-        has_json = not isinstance(json, _NoJsonData)
+        has_json = json is not _NO_JSON
 
         if files:
             # If the files keyword is present we will issue a

--- a/src/treq/client.py
+++ b/src/treq/client.py
@@ -217,10 +217,9 @@ class HTTPClient(object):
             json = json_dumps(json, separators=(u',', u':')).encode('utf-8')
             bodyProducer = self._data_to_body_producer(json)
 
-        if cookies is not None:
-            # merge_cookies actually alters the CookieJar
-            merge_cookies(self._cookiejar, cookies)
-        wrapped_agent = CookieAgent(self._agent, self._cookiejar)
+        cookies = dict() if cookies is None else cookies
+        cookies = merge_cookies(self._cookiejar, cookies)
+        wrapped_agent = CookieAgent(self._agent, cookies)
 
         if allow_redirects:
             if browser_like_redirects:

--- a/src/treq/test/test_client.py
+++ b/src/treq/test/test_client.py
@@ -420,17 +420,15 @@ class HTTPClientTests(TestCase):
 
         self.assertEqual(self.successResultOf(d).original, final_resp)
 
-    def test_request_unknown_arguments(self):
+    def _check_unknown_arguments(self, method, caller, *args, **kwargs):
         response = mock.Mock(headers=Headers({}))
         self.agent.request.return_value = succeed(response)
 
-        d = self.client.request('GET', 'http://www.example.com',
-                                _idontexist=True)
+        d = getattr(self.client, method)(_idontexist=True, *args, **kwargs)
 
         self.successResultOf(d)
 
-        warnings = self.flushWarnings(offendingFunctions=[
-            self.test_request_unknown_arguments])
+        warnings = self.flushWarnings(offendingFunctions=[caller])
 
         self.assertEqual(len(warnings), 1)
         self.assertEqual(warnings[0]['category'], DeprecationWarning)
@@ -439,6 +437,41 @@ class HTTPClientTests(TestCase):
             "^treq.client.HttpClient.request will only accept "
             "supported documented arguments. "
             "This will raise an Exception in the future. ")
+
+    def test_request_unknown_arguments(self):
+        self._check_unknown_arguments('request',
+                                      self.test_request_unknown_arguments,
+                                      'GET', 'www.http://example.com')
+
+    def test_get_unknown_arguments(self):
+        self._check_unknown_arguments('get',
+                                      self.test_get_unknown_arguments,
+                                      'www.http://example.com')
+
+    def test_put_unknown_arguments(self):
+        self._check_unknown_arguments('put',
+                                      self.test_put_unknown_arguments,
+                                      'www.http://example.com')
+
+    def test_patch_unknown_arguments(self):
+        self._check_unknown_arguments('patch',
+                                      self.test_patch_unknown_arguments,
+                                      'www.http://example.com')
+
+    def test_post_unknown_arguments(self):
+        self._check_unknown_arguments('post',
+                                      self.test_post_unknown_arguments,
+                                      'www.http://example.com')
+
+    def test_head_unknown_arguments(self):
+        self._check_unknown_arguments('head',
+                                      self.test_head_unknown_arguments,
+                                      'www.http://example.com')
+
+    def test_delete_unknown_arguments(self):
+        self._check_unknown_arguments('delete',
+                                      self.test_delete_unknown_arguments,
+                                      'www.http://example.com')
 
 
 class BodyBufferingProtocolTests(TestCase):

--- a/src/treq/test/test_client.py
+++ b/src/treq/test/test_client.py
@@ -420,6 +420,26 @@ class HTTPClientTests(TestCase):
 
         self.assertEqual(self.successResultOf(d).original, final_resp)
 
+    def test_request_unknown_arguments(self):
+        response = mock.Mock(headers=Headers({}))
+        self.agent.request.return_value = succeed(response)
+
+        d = self.client.request('GET', 'http://www.example.com',
+                                _idontexist=True)
+
+        self.successResultOf(d)
+
+        warnings = self.flushWarnings(offendingFunctions=[
+            self.test_request_unknown_arguments])
+
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0]['category'], DeprecationWarning)
+        self.assertRegex(
+            warnings[0]['message'],
+            "^treq.client.HttpClient.request will only accept "
+            "supported documented arguments. "
+            "This will raise an Exception in the future. ")
+
 
 class BodyBufferingProtocolTests(TestCase):
     def test_buffers_data(self):


### PR DESCRIPTION
PR following short conversation on IRC:

```
exarkun: ugh.  `treq.get`, etc all take **kwargs and silently ignore unrecognized arguments? :(
evilham: yup: https://github.com/twisted/treq/blob/master/src/treq/client.py#L144
only method and url are required, everything else is either used or ignored
exarkun: Bad.
evilham: maybe :-D yes, it shouldn't be too hard to patch, I agree I want the thing to explode in my face if I mistype `unbuffered` as `unbuffreed` instead of causing the whole system to swap and trash to death
```

^^^^ This has actually happened at some point :-) and is just awkward.


I consider this to be WIP because at the moment I have to stop and therefore can't add tests for "blow up in my face if passed unknown arguments", but since it shouldn't decrease coverage, is understandable and current tests pass, maybe if it passes review it can be fit for merging.

Notice that I had to change an internal API for this tow ork, shouldn't be too much of a problem I guess.