### PR TITLE
Exclude built docs from source package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,9 @@
 include README.rst LICENSE tox.ini tox2travis.py .coveragerc
 recursive-include docs *
 prune docs/_build
+prune docs/html
+
 exclude .travis.yml
 exclude .readthedocs.yml
 
-global-exclude .DS_Store *.pyc
+global-exclude .DS_Store *.pyc *.pyo __pycache__


### PR DESCRIPTION
Fixes this failure when running `tox -e docs && tox -e check-manifest`:

```
check-manifest run-test: commands[0] | check-manifest
lists of files in version control and sdist do not match!
missing from VCS:
  docs/html
  docs/html/.buildinfo
  docs/html/.doctrees
  docs/html/.doctrees/api.doctree
  docs/html/.doctrees/environment.pickle
  docs/html/.doctrees/howto.doctree
  docs/html/.doctrees/index.doctree
  docs/html/.doctrees/testing.doctree
  docs/html/_downloads
  docs/html/_downloads/21c3ef61009ab7283a17cb445c9921a8
  docs/html/_downloads/21c3ef61009ab7283a17cb445c9921a8/basic_auth.py
  docs/html/_downloads/3e64a2ec014262f001c671ca9238e211
  docs/html/_downloads/3e64a2ec014262f001c671ca9238e211/query_params.py
  docs/html/_downloads/613abf8bde51fe26d8d237fd009196d0
  docs/html/_downloads/613abf8bde51fe26d8d237fd009196d0/disable_redirects.py
  docs/html/_downloads/6826371dcfe74ca4686bfb45c24854d0
  docs/html/_downloads/6826371dcfe74ca4686bfb45c24854d0/using_cookies.py
  docs/html/_downloads/6f9a9795e8968898e2048fe2c86736d2
  docs/html/_downloads/6f9a9795e8968898e2048fe2c86736d2/redirects.py
  docs/html/_downloads/73eb6d23353462d332b38fea737146c8
  docs/html/_downloads/73eb6d23353462d332b38fea737146c8/basic_get.py
  docs/html/_downloads/8ef10dde4a156aacbeecea389b2c18a6
  docs/html/_downloads/8ef10dde4a156aacbeecea389b2c18a6/testing_seq.py
  docs/html/_downloads/9d0091fe37c08db0042cfdff4087e448
  docs/html/_downloads/9d0091fe37c08db0042cfdff4087e448/download_file.py
  docs/html/_downloads/a53c841bae430115ed47122b97fa1609
  docs/html/_downloads/a53c841bae430115ed47122b97fa1609/basic_post.py
  docs/html/_downloads/basic_auth.py
  docs/html/_downloads/basic_get.py
  docs/html/_downloads/basic_post.py
  docs/html/_downloads/disable_redirects.py
  docs/html/_downloads/download_file.py
  docs/html/_downloads/f6a3b89c4a9f60b04e544b7d6595e44d
  docs/html/_downloads/f6a3b89c4a9f60b04e544b7d6595e44d/response_history.py
  docs/html/_downloads/query_params.py
  docs/html/_downloads/redirects.py
  docs/html/_downloads/response_history.py
  docs/html/_downloads/testing_seq.py
  docs/html/_downloads/using_cookies.py
  docs/html/_modules
  docs/html/_modules/index.html
  docs/html/_modules/treq
  docs/html/_modules/treq/api.html
  docs/html/_modules/treq/client.html
  docs/html/_modules/treq/content.html
  docs/html/_modules/treq/multipart.html
  docs/html/_modules/treq/response.html
  docs/html/_modules/treq/testing.html
  docs/html/_modules/twisted
  docs/html/_modules/twisted/python
  docs/html/_modules/twisted/python/components.html
  docs/html/_sources
  docs/html/_sources/api.rst.txt
  docs/html/_sources/api.txt
  docs/html/_sources/howto.rst.txt
  docs/html/_sources/howto.txt
  docs/html/_sources/index.rst.txt
  docs/html/_sources/index.txt
  docs/html/_sources/testing.rst.txt
  docs/html/_static
  docs/html/_static/ajax-loader.gif
  docs/html/_static/basic.css
  docs/html/_static/classic.css
  docs/html/_static/comment-bright.png
  docs/html/_static/comment-close.png
  docs/html/_static/comment.png
  docs/html/_static/default.css
  docs/html/_static/doctools.js
  docs/html/_static/documentation_options.js
  docs/html/_static/down-pressed.png
  docs/html/_static/down.png
  docs/html/_static/file.png
  docs/html/_static/jquery-1.11.1.js
  docs/html/_static/jquery-3.1.0.js
  docs/html/_static/jquery-3.2.1.js
  docs/html/_static/jquery.js
  docs/html/_static/language_data.js
  docs/html/_static/minus.png
  docs/html/_static/plus.png
  docs/html/_static/pygments.css
  docs/html/_static/searchtools.js
  docs/html/_static/sidebar.js
  docs/html/_static/underscore-1.3.1.js
  docs/html/_static/underscore.js
  docs/html/_static/up-pressed.png
  docs/html/_static/up.png
  docs/html/_static/websupport.js
  docs/html/api.html
  docs/html/genindex.html
  docs/html/howto.html
  docs/html/index.html
  docs/html/objects.inv
  docs/html/py-modindex.html
  docs/html/search.html
  docs/html/searchindex.js
  docs/html/testing.html
ERROR: InvocationError for command /home/twm/treq/.tox/check-manifest/bin/check-manifest (exited with code 1)
```