### PR TITLE
Fix flake8 failure on Python 3

### DIFF
--- a/src/treq/client.py
+++ b/src/treq/client.py
@@ -341,7 +341,7 @@ registerAdapter(_from_file, BytesIO, IBodyProducer)
 if not _PY3:
     from StringIO import StringIO
     registerAdapter(_from_file, StringIO, IBodyProducer)
-    registerAdapter(_from_file, file, IBodyProducer)
+    registerAdapter(_from_file, open, IBodyProducer)
 else:
     import io
     # file()/open() equiv on Py3

--- a/src/treq/client.py
+++ b/src/treq/client.py
@@ -341,7 +341,8 @@ registerAdapter(_from_file, BytesIO, IBodyProducer)
 if not _PY3:
     from StringIO import StringIO
     registerAdapter(_from_file, StringIO, IBodyProducer)
-    registerAdapter(_from_file, open, IBodyProducer)
+    # Suppress lint failure on Python 3.
+    registerAdapter(_from_file, file, IBodyProducer)  # noqa: F821
 else:
     import io
     # file()/open() equiv on Py3


### PR DESCRIPTION
When Tox is installed under Python 3 its default interpreter is used to
run flake8. Python 3 doesn't define the `file` variable. While this is
part of a branch that only runs on Python 2 it's easiest to just switch
to the equivalent name `open`.

Fixes this failure:

    flake8 run-test: commands[0] | flake8 src/treq/
    src/treq/client.py:344:33: F821 undefined name 'file'