### PR TITLE
setup.py check → twine check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       dist: xenial
       sudo: true
     - python: '2.7'
-      env: TOXENV=pypi-readme
+      env: TOXENV=twine
     - python: '2.7'
       env: TOXENV=check-manifest
     - python: '2.7'

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
         {pypy,py27,py35,py36,py37}-twisted_{lowest,latest},
         {pypy,py27,py35,py36,py37}-twisted_trunk-pyopenssl_trunk,
-        pypi-readme, check-manifest, flake8, docs
+        twine, check-manifest, flake8, docs
 
 [testenv]
 extras = dev
@@ -33,11 +33,12 @@ skip_install = True
 deps = flake8
 commands = flake8 src/treq/
 
-[testenv:pypi-readme]
+[testenv:twine]
+python = python3
 deps =
-    readme_renderer
+    twine
 commands =
-    python setup.py check -r -s
+    twine check {distdir}/*.*
 
 [testenv:check-manifest]
 deps =


### PR DESCRIPTION
Resolve this warning:

    pypi-readme run-test: commands[0] | python setup.py check -r -s
    running check
    warning: Check: This command has been deprecated. Use `twine check` instead: https://packaging.python.org/guides/making-a-pypi-friendly-readme#validating-restructuredtext-markup

    The project's long description is valid RST.

Also rename the "pypi-readme" Tox environment to "twine" to match [the one with the same function in Twisted's tox.ini](https://github.com/twisted/twisted/blob/2f16887c734e8a29ab82e8cb5bc93b479c744597/tox.ini#L136).