### PR TITLE
Remove Python 2.7 Twisted trunk builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,8 @@ jobs:
       env: TOXENV=pypy-twisted_lowest,pypy-twisted_latest
     - python: "pypy3"
       env: TOXENV=pypy3-twisted_latest
-    - python: "pypy"
-      env: TOXENV=pypy-twisted_trunk-pyopenssl_trunk
-      if: branch = master
     - python: "pypy3"
       env: TOXENV=pypy3-twisted_trunk-pyopenssl_trunk
-      if: branch = master
-    - python: "2.7"
-      env: TOXENV=py27-twisted_trunk-pyopenssl_trunk
       if: branch = master
     - python: "3.5"
       env: TOXENV=py35-twisted_trunk-pyopenssl_trunk
@@ -47,9 +41,7 @@ jobs:
 
   # Don't fail on trunk versions.
   allow_failures:
-    - env: TOXENV=pypy-twisted_trunk-pyopenssl_trunk
     - env: TOXENV=pypy3-twisted_trunk-pyopenssl_trunk
-    - env: TOXENV=py27-twisted_trunk-pyopenssl_trunk
     - env: TOXENV=py35-twisted_trunk-pyopenssl_trunk
     - env: TOXENV=py36-twisted_trunk-pyopenssl_trunk
     - env: TOXENV=py37-twisted_trunk-pyopenssl_trunk

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     {pypy,py27,py35,py36,py37}-twisted_lowest,
     {pypy,pypy3,py27,py35,py36,py37,py38}-twisted_latest,
-    {pypy,pypy3,py27,py35,py36,py37,py38}-twisted_trunk-pyopenssl_trunk,
+    {pypy3,py35,py36,py37,py38}-twisted_trunk-pyopenssl_trunk,
     towncrier, twine, check-manifest, flake8, docs
 
 [testenv]


### PR DESCRIPTION
Twisted trunk no longer supports Python 2.7.