### PR TITLE
Update metadata to require six >= 1.13

### DIFF
--- a/changelog.d/295.bugfix.rst
+++ b/changelog.d/295.bugfix.rst
@@ -1,0 +1,1 @@
+treq's package metadata has been updated to require ``six >= 1.13``, noting a dependency introduced in treq 20.9.0.

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
             "incremental",
             "requests >= 2.1.0",
             "hyperlink >= 19.0.0",
-            "six",
+            "six >= 1.13.0",
             "Twisted[tls] >= 16.4.0 ; python_version < '3.7'",
             "Twisted[tls] >= 18.7.0 ; python_version >= '3.7'",
             "attrs",


### PR DESCRIPTION
This fixes a regression introduced in #290.

https://github.com/benjaminp/six/blob/c0be8815d13df45b6ae471c4c436cce8c192245d/CHANGES#L30-L31

Fixes #295.