### PR TITLE
Support Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,12 +63,16 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-          python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "pypy-2.7", "pypy-3.7"]
+          python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "pypy-2.7", "pypy-3.7"]
           twisted-version: ["lowest", "latest"]
           experimental: [false]
 
           include:
           - python-version: "3.8"
+            twisted-version: "trunk"
+            experimental: true
+
+          - python-version: "3.9"
             twisted-version: "trunk"
             experimental: true
 

--- a/changelog.d/305.feature.rst
+++ b/changelog.d/305.feature.rst
@@ -1,0 +1,1 @@
+Support for Python 3.9: treq is now tested with CPython 3.9.

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     {pypy,py27,py35,py36,py37}-twisted_lowest,
-    {pypy,pypy3,py27,py35,py36,py37,py38}-twisted_latest,
-    {pypy3,py35,py36,py37,py38}-twisted_trunk,
+    {pypy,pypy3,py27,py35,py36,py37,py38,py39}-twisted_latest,
+    {pypy3,py35,py36,py37,py38,py39}-twisted_trunk,
     towncrier, twine, check-manifest, flake8, docs
 
 [testenv]


### PR DESCRIPTION
Add Python 3.9 to the test matrix and package metadata.

Closes #305.