### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,5 @@ MANIFEST
 .coverage
 coverage
 htmlcov
-_trial_temp
+_trial_temp*
 .tox
-_trial_temp.lock

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,17 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+sphinx:
+  fail_on_warning: false
+
+formats:
+  - pdf
+  - epub
+
 python:
-  version: 2.7
-  pip_install: true
-  extra_requirements:
-    - dev
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,6 +14,7 @@ Lint::
 Build docs::
 
     tox -e docs
+    firefox docs/html/index.html
 
 To do it all::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,28 +1,23 @@
 Developing
 ==========
 
-Install dependencies:
+This project uses `Tox <https://tox.readthedocs.io/en/latest/config.html>`_ to manage virtual environments.
 
-::
+To run the tests::
 
-    pip install treq[dev]
+    tox -e py38-twisted_latest
 
-Run Tests (unit & integration):
+Lint::
 
-::
-
-    trial treq
-
-Lint:
-
-::
-
-    pep8 treq
-    pyflakes treq
+    tox -e flake8
 
 Build docs::
 
     tox -e docs
+
+To do it all::
+
+    tox -p
 
 Release notes
 -------------

--- a/changelog.d/296.doc.rst
+++ b/changelog.d/296.doc.rst
@@ -1,0 +1,1 @@
+The dependency on Sphinx required to build the documentation has been moved from the ``dev`` extra to the new ``docs`` extra.

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,10 @@ if __name__ == "__main__":
                 "mock",
                 "pep8",
                 "pyflakes",
-                "sphinx",
                 "httpbin==0.5.0",
+            ],
+            "docs": [
+                "sphinx>=1.4.8",
             ],
         },
         package_data={"treq": ["_version"]},

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,6 @@ deps =
     twisted_lowest: Twisted==18.7.0
     twisted_latest: Twisted
     twisted_trunk: https://github.com/twisted/twisted/archive/trunk.zip
-
-    docs: Sphinx>=1.4.8
 setenv =
     # Avoid unnecessary network access when creating virtualenvs for speed.
     VIRTUALENV_NO_DOWNLOAD=1
@@ -54,6 +52,7 @@ commands =
     check-manifest
 
 [testenv:docs]
+extras = docs
 changedir = docs
 commands =
     sphinx-build -b html . html


### PR DESCRIPTION
- Use Python 3.7 instead of 2.7 to build the documentation
- Move the Sphinx dependency to the ``docs`` extra

I've also enabled PR builds in the ReadTheDocs configuration, so the build status should be reported here.

Closes #296.
