### PR TITLE
treq.testing.StubTreq: fix persisting twisted.web.server.Session objects between requests

### DIFF
--- a/changelog.d/327.bugfix.rst
+++ b/changelog.d/327.bugfix.rst
@@ -1,0 +1,1 @@
+``treq.testing.StubTreq`` now persists ``twisted.web.server.Session`` instances between requests.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -114,6 +114,14 @@ StubTreq Objects
         asynchronous. In that case, after each write from the server,
         :meth:`flush()` must be called so the client can see it.
 
+    .. method:: cleanSessions()
+
+        Clean up sessions to prevent leaving behind a dirty reactor.
+
+        If you are using :obj:`StubTreq` with :obj:`twisted.web.server.Session`
+        objects, you most likely have to call this method once you are done,
+        for example during the tearDown of a unittest TestCase.
+
     As the methods on :class:`treq.client.HTTPClient`:
 
     .. method:: request

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -114,14 +114,6 @@ StubTreq Objects
         asynchronous. In that case, after each write from the server,
         :meth:`flush()` must be called so the client can see it.
 
-    .. method:: cleanSessions()
-
-        Clean up sessions to prevent leaving behind a dirty reactor.
-
-        If you are using :obj:`StubTreq` with :obj:`twisted.web.server.Session`
-        objects, you most likely have to call this method once you are done,
-        for example during the tearDown of a unittest TestCase.
-
     As the methods on :class:`treq.client.HTTPClient`:
 
     .. method:: request

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -58,5 +58,3 @@ Thus, the ``request`` object your code interacts with is a *real* :class:`twiste
 
 Note that if your resource returns :data:`~twisted.web.server.NOT_DONE_YET` you must keep a reference to the :class:`~treq.testing.RequestTraversalAgent` and call its :meth:`~treq.testing.RequestTraversalAgent.flush()` method to spin the memory reactor once the server writes additional data before the client will receive it.
 
-If you are using :class:`~twisted.web.server.Session` instances in the wrapped resource, you may need to call :meth:`~treq.testing.StubTreq.cleanSessions()` to expire all sessions and prevent an unclean/dirty reactor.
-

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -57,3 +57,6 @@ This is superior to calling your resource's methods directly or passing mock obj
 Thus, the ``request`` object your code interacts with is a *real* :class:`twisted.web.server.Request` and behaves the same as it would in production.
 
 Note that if your resource returns :data:`~twisted.web.server.NOT_DONE_YET` you must keep a reference to the :class:`~treq.testing.RequestTraversalAgent` and call its :meth:`~treq.testing.RequestTraversalAgent.flush()` method to spin the memory reactor once the server writes additional data before the client will receive it.
+
+If you are using :class:`~twisted.web.server.Session` instances in the wrapped resource, you may need to call :meth:`~treq.testing.StubTreq.cleanSessions()` to expire all sessions and prevent an unclean/dirty reactor.
+

--- a/src/treq/test/test_testing.py
+++ b/src/treq/test/test_testing.py
@@ -273,7 +273,11 @@ class StubbingTests(TestCase):
         self.assertEqual(sid_1, sid_2)
         # request 3, ensuring the session IDs are different after cleaning
         # or expiring the sessions
-        stub.cleanSessions()
+
+        # manually expire the sessions.
+        for sid in list(stub._agent._serverFactory.sessions.keys()):
+            stub._agent._serverFactory.sessions[sid].expire()
+
         d = stub.request("method", "http://example.com/")
         resp = self.successResultOf(d)
         cookies = resp.cookies()
@@ -284,8 +288,12 @@ class StubbingTests(TestCase):
         resp = self.successResultOf(d)
         sid_4 = self.successResultOf(resp.content())
         self.assertEqual(sid_3, sid_4)
+
         # when done, clean sessions to avoid leaving a dirty reactor behind
-        stub.cleanSessions()
+        # NOTE: this is a temporary fix discussed in #328.
+        # This should be removed once twisted ticked #10177 is fixed
+        for sid in list(stub._agent._serverFactory.sessions.keys()):
+            stub._agent._serverFactory.sessions[sid].expire()
 
 
 class HasHeadersTests(TestCase):

--- a/src/treq/testing.py
+++ b/src/treq/testing.py
@@ -89,7 +89,11 @@ class RequestTraversalAgent:
             endpointFactory=_EndpointFactory(self._memoryReactor))
         self._rootResource = rootResource
         self._serverFactory = Site(self._rootResource, reactor=self._memoryReactor)
-        self._serverFactory.sessionFactory = lambda site, uid: Session(site, uid, reactor=self._memoryReactor)
+        self._serverFactory.sessionFactory = lambda site, uid: Session(
+            site,
+            uid,
+            reactor=self._memoryReactor,
+        )
         self._pumps = set()
 
     def request(self, method, uri, headers=None, bodyProducer=None):

--- a/src/treq/testing.py
+++ b/src/treq/testing.py
@@ -241,16 +241,6 @@ class StubTreq:
             setattr(self, function_name, function)
         self.flush = self._agent.flush
 
-    def cleanSessions(self):
-        """
-        Clean up sessions to prevent leaving behind a dirty reactor.
-        If you are using :obj:`StubTreq` with :obj:`twisted.web.server.Session`
-        objects, you most likely have to call this method once you are done,
-        for example during the tearDown of a unittest TestCase.
-        """
-        for sid in list(self._agent._serverFactory.sessions.keys()):
-            self._agent._serverFactory.sessions[sid].expire()
-
 
 class StringStubbingResource(Resource):
     """

--- a/src/treq/testing.py
+++ b/src/treq/testing.py
@@ -26,7 +26,7 @@ from twisted.web.client import Agent
 from twisted.web.error import SchemeNotSupported
 from twisted.web.iweb import IAgent, IAgentEndpointFactory, IBodyProducer
 from twisted.web.resource import Resource
-from twisted.web.server import Site
+from twisted.web.server import Session, Site
 
 from zope.interface import directlyProvides, implementer
 
@@ -89,6 +89,7 @@ class RequestTraversalAgent:
             endpointFactory=_EndpointFactory(self._memoryReactor))
         self._rootResource = rootResource
         self._serverFactory = Site(self._rootResource, reactor=self._memoryReactor)
+        self._serverFactory.sessionFactory = lambda site, uid: Session(site, uid, reactor=self._memoryReactor)
         self._pumps = set()
 
     def request(self, method, uri, headers=None, bodyProducer=None):


### PR DESCRIPTION
This PR contains my proposed fix for #327. For details about the issue and this fix, see said issue.

**tl;dr of original issue:** Previously, a resource wrapped by `treq.testing.StubTreq` could not properly use `request.getSession()`, as it would always create a new `twisted.web.server.Session` instead of returning the same one. This is because `treq.testing.StubTreq` always create a new instance of `twisted.web.server.Site` for each request. As sessions are stored within a `Site` instance, this meant that upon completion of a request, the original session was lost. This PR solves this issue by moving the `twisted.web.server.Site` instance to an attribute of the agent. Additionally, the new `treq.testing.StubTreq.cleanSessions()` method provides a simple way of expiring the sessions in order to avoid leaving behind a dirty/unclean reactor. Although I am not sure if this is the best way to do this.