### PR TITLE
Add PEP 517 / PEP 518 metadata

### DIFF
--- a/changelog.d/329.feature.rst
+++ b/changelog.d/329.feature.rst
@@ -1,0 +1,1 @@
+PEP 517/518 ``build-system`` metadata is now provided in ``pyproject.toml``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[build-system]
+requires = [
+    "setuptools >= 35.0.2",
+    "wheel >= 0.29.0",
+    "incremental >= 21.3.0",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.towncrier]
 package = "treq"
 package_dir = "src"

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     {pypy3,py36,py37,py38,py39}-twisted_latest,
     {pypy3,py36,py37,py38,py39}-twisted_trunk,
     towncrier, twine, check-manifest, flake8, docs
+isolated_build = true
 
 [testenv]
 extras = dev


### PR DESCRIPTION
This moves the build-time dependency on incremental to a declarativefile. See [1] for background.

[1]: https://twistedmatrix.com/trac/ticket/9457