### PR TITLE
Cleanup: remove bytes decoding for quoted result

### DIFF
--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -145,10 +145,10 @@ Customizing the Twisted Agent
 
 The main :py:mod:`treq` module has helper functions that automatically instantiate
 an instance of :py:class:`treq.client.HTTPClient`.  You can create an instance
-of :py:class:`~treq.client.HTTPClient` directly in order to customize the 
-paramaters used to initialize it.
-Internally, the :py:class:`~treq.client.HTTPClient` wraps an instance of 
-:py:class:`twisted.web.client.Agent`.  When you create an instance of 
+of :py:class:`~treq.client.HTTPClient` directly in order to customize the
+parameters used to initialize it.
+Internally, the :py:class:`~treq.client.HTTPClient` wraps an instance of
+:py:class:`twisted.web.client.Agent`.  When you create an instance of
 :py:class:`~treq.client.HTTPClient`, you must initialize it with an instance of
 :py:class:`~twisted.web.client.Agent`.  This allows you to customize its
 behavior.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,7 +83,7 @@ Here is a list of `requests`_ features and their status in treq.
 +----------------------------------+----------+----------+
 | Connection Timeouts              | yes      | yes      |
 +----------------------------------+----------+----------+
-| HTTP(S) Proxy Suport             | yes      | no       |
+| HTTP(S) Proxy Support             | yes      | no       |
 +----------------------------------+----------+----------+
 | .netrc support                   | yes      | no       |
 +----------------------------------+----------+----------+

--- a/src/treq/client.py
+++ b/src/treq/client.py
@@ -429,11 +429,6 @@ def _query_quote(v):
     if not isinstance(v, bytes):
         v = v.encode("utf-8")
     q = quote_plus(v)
-    if isinstance(q, bytes):
-        # Python 2.7 returnes bytes when given bytes, but Python 3.x always
-        # returns str.  Coverage disabled here to stop Coveralls complaining
-        # until we can drop Python 2.7 support.
-        q = q.decode("ascii")  # pragma: no cover
     return q
 
 

--- a/src/treq/multipart.py
+++ b/src/treq/multipart.py
@@ -155,7 +155,7 @@ class MultiPartProducer:
 
             # It's also important to note that the boundary in the message
             # is defined not only by "--boundary-value" but
-            # but with CRLF characers before it and after the line.
+            # but with CRLF characters before it and after the line.
             # This is very important.
             # proper boundary is "CRLF--boundary-valueCRLF"
             consumer.write(


### PR DESCRIPTION
Remove byte decoding for return value of `quote_plus()`. Not needed after we dropped Python 2 support.