### PR TITLE
Fix cookie scoping for HTTPS urls.

### DIFF
--- a/src/treq/client.py
+++ b/src/treq/client.py
@@ -60,7 +60,7 @@ def _scoped_cookiejar_from_dict(url_object, cookie_dict):
             (url_object.scheme == "https" and url_object.port == 443)
             or (url_object.scheme == "http" and url_object.port == 80)
         )
-        port = str(url_object.port)
+        port = str(url_object.port) if port_specified else None
         domain = url_object.host
         netscape_domain = domain if '.' in domain else domain + '.local'
 


### PR DESCRIPTION
If Cookie.port is specified not None then CookieJar will attempt to
compare it to the port for the Request object by first parsing it out of
`Request.host` and if there is no port specified there falling back to
the `DEFAULT_HTTP_PORT` value of 80.

This caused cookies to never be sent for HTTPS domains because the
Cookie.port was set to 443, and the _FakeUrllib2Request.host did not
contain the default port value.

I've also added a test to make sure non-default port values work properly.