### PR TITLE
Build on trunk and PRs that target trunk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ trunk ]
   pull_request:
-    branches: [ master ]
+    branches: [ trunk ]
 
 jobs:
   lint:


### PR DESCRIPTION
It looks like when the default branch was renamed Github Actions workflow triggers didn't get updated.