### PR TITLE
Handle exceptions raised from the collector passed to treq.content()

### DIFF
--- a/changelog.d/347.feature.rst
+++ b/changelog.d/347.feature.rst
@@ -1,0 +1,1 @@
+When the collector passed to ``treq.collect(response, collector)`` throws an exception, that error will now be returned to the caller of ``collect()`` via the result ``Deferred``, and the underlying HTTP transport will be closed.

--- a/src/treq/content.py
+++ b/src/treq/content.py
@@ -2,7 +2,7 @@ import cgi
 import json
 
 from twisted.internet.defer import Deferred, succeed
-
+from twisted.python.failure import Failure
 from twisted.internet.protocol import Protocol
 from twisted.web.client import ResponseDone
 from twisted.web.http import PotentialDataLoss
@@ -30,9 +30,16 @@ class _BodyCollector(Protocol):
         self.collector = collector
 
     def dataReceived(self, data):
-        self.collector(data)
+        try:
+            self.collector(data)
+        except:  # noqa: bare-except
+            self.transport.loseConnection()
+            self.finished.errback(Failure())
+            self.finished = None
 
     def connectionLost(self, reason):
+        if self.finished is None:
+            return
         if reason.check(ResponseDone):
             self.finished.callback(None)
         elif reason.check(PotentialDataLoss):
@@ -48,9 +55,13 @@ def collect(response, collector):
 
     This function may only be called **once** for a given response.
 
+    If the ``collector`` raises an exception, it will be set as the error value
+    on response ``Deferred`` returned from this function, and the underlying
+    HTTP transport will be closed.
+
     :param IResponse response: The HTTP response to collect the body from.
-    :param collector: A callable to be called each time data is available
-        from the response body.
+    :param collector: A callable to be called each time data is available from
+        the response body.
     :type collector: single argument callable
 
     :rtype: Deferred that fires with None when the entire body has been read.

--- a/src/treq/content.py
+++ b/src/treq/content.py
@@ -32,7 +32,7 @@ class _BodyCollector(Protocol):
     def dataReceived(self, data):
         try:
             self.collector(data)
-        except:  # noqa: bare-except
+        except BaseException:
             self.transport.loseConnection()
             self.finished.errback(Failure())
             self.finished = None

--- a/src/treq/test/test_content.py
+++ b/src/treq/test/test_content.py
@@ -253,7 +253,7 @@ class MoreRealisticContentTests(TestCase):
 
         # Exceptions in the collector are passed on to the caller via the
         # response Deferred:
-        self.assertFailure(d, ZeroDivisionError)
+        self.failureResultOf(d, ZeroDivisionError)
 
         # An exception in the protocol results in the transport for the request
         # being closed.

--- a/src/treq/test/test_content.py
+++ b/src/treq/test/test_content.py
@@ -231,7 +231,7 @@ class UnfinishedResponse(Resource):
 
 
 class MoreRealisticContentTests(TestCase):
-    """Tests involve less mocking."""
+    """Tests involving less mocking."""
 
     def test_exception_handling(self):
         """
@@ -240,7 +240,7 @@ class MoreRealisticContentTests(TestCase):
             1. Always gets returned in the result ``Deferred`` from
                ``treq.collect()``.
 
-            2. Closes the transport to be closed.
+            2. Closes the transport.
         """
         stub = StubTreq(UnfinishedResponse())
         response = self.successResultOf(stub.request("GET", "http://127.0.0.1/"))


### PR DESCRIPTION
Fixes #347 
