### PR TITLE
Bump release dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.11'
 
     - uses: actions/cache@v3
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
           ${{ runner.os }}-pip-docs-
           ${{ runner.os }}-pip-
 
-    - run: python -m pip install tox
+    - run: python -m pip install 'tox<4'
 
     - run: tox -q -e docs
 
@@ -63,15 +63,35 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-          python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8", "pypy-3.9"]
+          # Python versions common to lowest and latest
+          python-version: ["3.8", "3.9", "3.10", "pypy-3.9"]
           twisted-version: ["lowest", "latest"]
           experimental: [false]
 
           include:
-          - python-version: "3.8"
-            twisted-version: "trunk"
-            experimental: true
+          # Pythons too old for latest
+          - python-version: "3.7"
+            twisted-version: "lowest"
+            experimental: false
 
+          - python-version: "pypy-3.8"
+            twisted-version: "lowest"
+            experimental: false
+
+          # Pythons too new for lowest
+          - python-version: "3.11"
+            twisted-version: "latest"
+            experimental: false
+
+          - python-version: "3.12"
+            twisted-version: "latest"
+            experimental: false
+
+          - python-version: "pypy-3.10"
+            twisted-version: "latest"
+            experimental: false
+
+          # Experimental trunk build
           - python-version: "3.9"
             twisted-version: "trunk"
             experimental: true
@@ -101,8 +121,11 @@ jobs:
           "3.8": "py38",
           "3.9": "py39",
           "3.10": "py310",
+          "3.11": "py311",
+          "3.12": "py312",
           "pypy-3.8": "pypy3",
           "pypy-3.9": "pypy3",
+          "pypy-3.10": "pypy3",
         }
         factor = table["${{ matrix.python-version }}"]
         print("::set-output name=value::" + factor)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,3 +140,28 @@ jobs:
         COVERALLS_REPO_TOKEN: 4nctuKHTnVtbdmty2FgdO3iiWm1nb7xc4
         COVERALLS_FLAG_NAME: python_${{ matrix.python-version }}-twisted_${{ matrix.twisted-version }}
         COVERALLS_PARALLEL: true
+
+  # Helper so that on GitHub repo settings we can configure to single job.
+  # Then required jobs can be updated directly form the code,
+  # without having to go the GitHub repo setting -> Protected branch
+  # and all the clicking.
+  treq-required:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: always()
+    # Add here the jobs that should block the merge of a PR.
+    needs:
+      - lint
+      - docs
+      - test
+    steps:
+      - name: Require all successes
+        shell: python3 {0}
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          import json
+          import os
+          import sys
+          results = json.loads(os.environ["RESULTS"])
+          sys.exit(0 if all(result == "success" for result in results) else 1)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,7 +148,7 @@ jobs:
   treq-required:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: always()
+    if: ${{ !cancelled() }}
     # Add here the jobs that should block the merge of a PR.
     needs:
       - lint

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@ dist
 /docs/html
 /.eggs
 MANIFEST
-.coverage
+/.coverage
+/.coverage.*
 coverage
 htmlcov
 _trial_temp*
-.tox
+/.tox

--- a/changelog.d/364.feature.rst
+++ b/changelog.d/364.feature.rst
@@ -1,0 +1,1 @@
+Python 3.11 is now supported.

--- a/changelog.d/374.feature.rst
+++ b/changelog.d/374.feature.rst
@@ -1,0 +1,1 @@
+PyPy 3.10 is now supported.

--- a/changelog.d/374.removal.rst
+++ b/changelog.d/374.removal.rst
@@ -1,0 +1,3 @@
+Support for PyPy 3.8, which has reached end of support, is deprecated. This is the last release with support for PyPy 3.8.
+
+The minimum supported Twisted version has increased to 22.10.0. Older versions are no longer tested in CI.

--- a/changelog.d/375.feature.rst
+++ b/changelog.d/375.feature.rst
@@ -1,0 +1,1 @@
+Python 3.12 is now supported.

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Framework :: Twisted",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -32,7 +32,7 @@ if __name__ == "__main__":
             "incremental",
             "requests >= 2.1.0",
             "hyperlink >= 21.0.0",
-            "Twisted[tls] >= 18.7.0",
+            "Twisted[tls] >= 22.10.0",
             "attrs",
         ],
         extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -26,25 +26,27 @@ commands =
     {envbindir}/trial {posargs:treq}
 
 [testenv:flake8]
+python = python3.11
 skip_install = True
 deps = flake8
 commands = flake8 src/treq/
 
 [testenv:towncrier]
-python = python3
+python = python3.11
 deps =
     towncrier
 commands =
     towncrier {posargs:--draft}
 
 [testenv:twine]
-python = python3
+python = python3.11
 deps =
     twine
 commands =
     twine check {distdir}/*.*
 
 [testenv:check-manifest]
+python = python3.11
 deps =
     check-manifest
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     py37-twisted_lowest,
-    {pypy3,py37,py38,py39,py310}-twisted_latest,
-    {pypy3,py37,py38,py39,py310}-twisted_trunk,
+    {pypy3,py38,py39,py310,py311,py312}-twisted_latest,
+    {pypy3,py38,py39,py310,py311,py312}-twisted_trunk,
     twine, check-manifest, flake8, docs, coverage-report
 isolated_build = true
 
@@ -11,7 +11,7 @@ extras = dev
 deps =
     coverage
 
-    twisted_lowest: Twisted==18.7.0
+    twisted_lowest: Twisted==22.10.0
     twisted_latest: Twisted
     twisted_trunk: https://github.com/twisted/twisted/archive/trunk.zip
 setenv =
@@ -60,7 +60,7 @@ commands =
     sphinx-build -b html . html
 
 [testenv:coverage-report]
-depends = pypy3,py37,py38,py39
+depends = pypy3,py37,py38,py39,py310,py311,py312
 commands =
     coverage combine
     coverage report


### PR DESCRIPTION
Let's do a release!

- Twisted 23.10.0 dropped support for Python 3.7.
- Towncrier 23.10.0 dropped support for Python 3.7.

Fixes #364. Fixes #375.
