### PR TITLE
github action: Move tests running on Ubuntu 22.04 to get suport for Python 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
 
   test:
     name: "Test ${{ matrix.python-version }} with ${{ matrix.twisted-version }} Twisted"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     continue-on-error: ${{ matrix.experimental }}
     strategy:


### PR DESCRIPTION


Fixes #393