### PR TITLE
Green up the tests

### DIFF
--- a/src/treq/test/local_httpbin/child.py
+++ b/src/treq/test/local_httpbin/child.py
@@ -16,7 +16,7 @@ from twisted.internet.task import react
 from twisted.internet.ssl import (Certificate,
                                   CertificateOptions)
 
-from OpenSSL.crypto import PKey, X509  # type: ignore
+from OpenSSL.crypto import PKey, X509
 
 from twisted.python.threadpool import ThreadPool
 from twisted.web.server import Site

--- a/src/treq/test/test_content.py
+++ b/src/treq/test/test_content.py
@@ -207,14 +207,16 @@ class ContentTests(TestCase):
 
     def test_text_content_unicode_headers(self):
         """
-        Header parsing is robust against unicode header names and values.
+        Parsing of the Content-Type header is robust in the face of
+        Unicode gunk in the header value, which is ignored.
         """
-        self.response.headers = Headers({
-            b'Content-Type': [
-                u'text/plain; charset="UTF-16BE"; u=ᛃ'.encode('utf-8')],
-            u'Coördination'.encode('iso-8859-1'): [
-                u'koʊˌɔrdɪˈneɪʃən'.encode('utf-8')],
-        })
+        self.response.headers = Headers(
+            {
+                b"Content-Type": [
+                    'text/plain; charset="UTF-16BE"; u=ᛃ'.encode("utf-8")
+                ],
+            }
+        )
 
         d = text_content(self.response)
 


### PR DESCRIPTION
Remove an invalid HTTP header name from a test case. The header name itself appears to be dead code — the code under test only parses the Content-Type header.

Fixes #395.
