### PR TITLE
just address some minor local development annoyances

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ if __name__ == "__main__":
             "dev": [
                 "pep8",
                 "pyflakes",
-                "httpbin==0.7.0",
-                "werkzeug==2.0.3",
+                "httpbin==0.10.2",
+                "werkzeug==3.0.4",
             ],
             "docs": [
                 "sphinx<7.0.0",  # Removal of 'style' key breaks RTD.

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
     pip list
     python -Wall \
     {envbindir}/coverage run -p \
-    {envbindir}/trial {posargs:treq}
+    {envbindir}/trial --temp-directory={envtmpdir}/_trial_temp {posargs:treq}
 
 [testenv:mypy]
 basepython = python3.12


### PR DESCRIPTION
- upgrade `httpbin` and `werkzeug` pins in `dev` extra
- use an appropriately-located temp dir for trial's temp files so we don't litter `_trial_temp-$N` all over the working copy

longer term we should fix these pins some other way, but in the meanwhile let's catch up to real time

Fixes #354.