### PR TITLE
Stop using twisted.internet.defer.returnValue

### DIFF
--- a/docs/examples/testing_seq.py
+++ b/docs/examples/testing_seq.py
@@ -18,7 +18,7 @@ def make_a_request(treq):
     else:
         message = yield response.text()
         raise Exception("Got an error from the server: {}".format(message))
-    defer.returnValue(result)
+    return result
 
 
 class MakeARequestTests(SynchronousTestCase):


### PR DESCRIPTION
`defer.returnValue` was only needed in Python 2; in Python 3, a simple `return` is fine.

`twisted.internet.defer.returnValue` is deprecated as of Twisted 24.7.0.