### PR TITLE
Shinier documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Features
 --------
 
 - treq now ships type annotations. (`#366 <https://github.com/twisted/treq/issues/366>`__)
-- The new :mod:`treq.cookies` module provides helper functions for working with `http.cookiejar.Cookie` and `CookieJar` objects. (`#384 <https://github.com/twisted/treq/issues/384>`__)
+- The new :mod:`treq.cookies` module provides helper functions for working with `http.cookiejar.Cookie` and :class:`~http.cookiejar.CookieJar` objects. (`#384 <https://github.com/twisted/treq/issues/384>`__)
 - Python 3.13 is now supported. (`#391 <https://github.com/twisted/treq/issues/391>`__)
 
 
@@ -40,7 +40,7 @@ Deprecations and Removals
 -------------------------
 
 - Mixing the *json* argument with *files* or *data* now raises `TypeError`. (`#297 <https://github.com/twisted/treq/issues/297>`__)
-- Passing non-string (`str` or `bytes`) values as part of a dict to the *headers* argument now results in a `TypeError`, as does passing any collection other than a `dict` or `Headers` instance. (`#302 <https://github.com/twisted/treq/issues/302>`__)
+- Passing non-string (`str` or `bytes`) values as part of a dict to the *headers* argument now results in a `TypeError`, as does passing any collection other than a `dict` or :class:`~twisted.web.http.http_headers.Headers` instance. (`#302 <https://github.com/twisted/treq/issues/302>`__)
 - Support for Python 3.7 and PyPy 3.8, which have reached end of support, has been dropped. (`#378 <https://github.com/twisted/treq/issues/378>`__)
 
 

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ treq: High-level Twisted HTTP Client API
 
 ``treq`` is an HTTP library inspired by
 `requests <https://requests.readthedocs.io/>`_ but written on top of
-`Twisted <https://www.twistedmatrix.com>`_'s
-`Agents <https://twistedmatrix.com/documents/current/api/twisted.web.client.Agent.html>`_.
+`Twisted <https://twisted.org/>`_'s
+`Agents <https://docs.twisted.org/en/stable/api/twisted.web.client.Agent.html>`_.
 
 It provides a simple, higher level API for making HTTP requests when
 using Twisted.

--- a/changelog.d/409.doc.rst
+++ b/changelog.d/409.doc.rst
@@ -1,0 +1,1 @@
+Update documentation to use `async`/`await` syntax

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ extensions = [
 templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = ".rst"
+source_suffix = {".rst": "restructuredtext"}
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,12 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.viewcode", "sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
+extensions = [
+    "sphinx.ext.viewcode",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx_rtd_theme",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -92,7 +97,7 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "default"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,10 +99,13 @@ pygments_style = "sphinx"
 # a list of builtin themes.
 html_theme = "sphinx_rtd_theme"
 
+# https://docs.readthedocs.com/platform/stable/intro/sphinx.html#set-the-canonical-url
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {"flyout_display": "attached"}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []

--- a/docs/examples/_utils.py
+++ b/docs/examples/_utils.py
@@ -1,10 +1,7 @@
-from __future__ import print_function
-
 import treq
 
 
-def print_response(response):
+async def print_response(response):
     print(response.code, response.phrase)
     print(response.headers)
-
-    return treq.text_content(response).addCallback(print)
+    print(await treq.text_content(response))

--- a/docs/examples/basic_auth.py
+++ b/docs/examples/basic_auth.py
@@ -1,15 +1,15 @@
-from twisted.internet.task import react
 from _utils import print_response
+from twisted.internet.task import react
 
 import treq
 
 
-def main(reactor, *args):
-    d = treq.get(
-        'https://httpbin.org/basic-auth/treq/treq',
-        auth=('treq', 'treq')
+async def main(reactor):
+    response = await treq.get(
+        "https://httpbin.org/basic-auth/treq/treq",
+        auth=("treq", "treq"),
     )
-    d.addCallback(print_response)
-    return d
+    await print_response(response)
 
-react(main, [])
+
+react(main)

--- a/docs/examples/basic_auth.py
+++ b/docs/examples/basic_auth.py
@@ -4,12 +4,12 @@ from twisted.internet.task import react
 import treq
 
 
-async def main(reactor):
-    response = await treq.get(
+async def basic_auth(reactor):
+    resp = await treq.get(
         "https://httpbin.org/basic-auth/treq/treq",
         auth=("treq", "treq"),
     )
-    await print_response(response)
+    await print_response(resp)
 
 
-react(main)
+react(basic_auth)

--- a/docs/examples/basic_get.py
+++ b/docs/examples/basic_get.py
@@ -1,12 +1,13 @@
 from twisted.internet.task import react
-from _utils import print_response
 
 import treq
 
 
-def main(reactor, *args):
-    d = treq.get('https://httpbin.org/get')
-    d.addCallback(print_response)
-    return d
+async def basic_get(reactor):
+    resp = await treq.get("https://httpbin.org/get")
+    print(resp.code, resp.phrase)
+    print(resp.headers)
+    print(await resp.text())
 
-react(main, [])
+
+react(basic_get)

--- a/docs/examples/basic_post.py
+++ b/docs/examples/basic_post.py
@@ -1,13 +1,15 @@
-from twisted.internet.task import react
 from _utils import print_response
+from twisted.internet.task import react
 
 import treq
 
 
-def main(reactor):
-    d = treq.post("https://httpbin.org/post",
-                  data={"form": "data"})
-    d.addCallback(print_response)
-    return d
+def basic_post(reactor):
+    resp = await treq.post(
+        "https://httpbin.org/post",
+        data={"form": "data"},
+    )
+    await print_response(resp)
 
-react(main, [])
+
+react(basic_post)

--- a/docs/examples/basic_url.py
+++ b/docs/examples/basic_url.py
@@ -5,7 +5,7 @@ from twisted.internet.task import react
 import treq
 
 
-async def main(reactor):
+async def basic_url(reactor):
     url = (
         DecodedURL.from_text("https://httpbin.org")
         .child("get")  # add path /get
@@ -15,4 +15,4 @@ async def main(reactor):
     await print_response(await treq.get(url))
 
 
-react(main)
+react(basic_url)

--- a/docs/examples/basic_url.py
+++ b/docs/examples/basic_url.py
@@ -1,17 +1,18 @@
-# -*- encoding: utf-8 -*-
+from _utils import print_response
 from hyperlink import DecodedURL
 from twisted.internet.task import react
-from _utils import print_response
 
 import treq
 
-def main(reactor):
+
+async def main(reactor):
     url = (
-        DecodedURL.from_text(u"https://httpbin.org")
-        .child(u"get")      # add path /get
-        .add(u"foo", u"&")  # add query ?foo=%26
+        DecodedURL.from_text("https://httpbin.org")
+        .child("get")  # add path /get
+        .add("foo", "&")  # add query ?foo=%26
     )
     print(url.to_text())
-    return treq.get(url).addCallback(print_response)
+    await print_response(await treq.get(url))
 
-react(main, [])
+
+react(main)

--- a/docs/examples/custom_agent.py
+++ b/docs/examples/custom_agent.py
@@ -5,9 +5,9 @@ from twisted.web.client import Agent
 from treq.client import HTTPClient
 
 
-async def main(reactor):
-    custom_agent = Agent(reactor, connectTimeout=42)
-    http_client = HTTPClient(custom_agent)
+async def custom_agent(reactor):
+    my_agent = Agent(reactor, connectTimeout=42)
+    http_client = HTTPClient(my_agent)
     resp = await http_client.get(
         "https://secure.example.net/area51",
         auth=("admin", "you'll never guess!"),
@@ -15,4 +15,4 @@ async def main(reactor):
     await print_response(resp)
 
 
-react(main)
+react(custom_agent)

--- a/docs/examples/custom_agent.py
+++ b/docs/examples/custom_agent.py
@@ -1,19 +1,18 @@
-from treq.client import HTTPClient
 from _utils import print_response
 from twisted.internet.task import react
 from twisted.web.client import Agent
 
-def make_custom_agent(reactor):
-    return Agent(reactor, connectTimeout=42)
+from treq.client import HTTPClient
 
-def main(reactor, *args):
-    agent = make_custom_agent(reactor)
-    http_client = HTTPClient(agent)
-    d = http_client.get(
-        'https://secure.example.net/area51',
-        auth=('admin', "you'll never guess!"))
-    d.addCallback(print_response)
-    return d
 
-react(main, [])
+async def main(reactor):
+    custom_agent = Agent(reactor, connectTimeout=42)
+    http_client = HTTPClient(custom_agent)
+    resp = await http_client.get(
+        "https://secure.example.net/area51",
+        auth=("admin", "you'll never guess!"),
+    )
+    await print_response(resp)
 
+
+react(main)

--- a/docs/examples/disable_redirects.py
+++ b/docs/examples/disable_redirects.py
@@ -1,12 +1,15 @@
-from twisted.internet.task import react
 from _utils import print_response
+from twisted.internet.task import react
 
 import treq
 
 
-def main(reactor, *args):
-    d = treq.get('https://httpbin.org/redirect/1', allow_redirects=False)
-    d.addCallback(print_response)
-    return d
+async def main(reactor):
+    response = await treq.get(
+        "https://httpbin.org/redirect/1",
+        allow_redirects=False,
+    )
+    await print_response(response)
 
-react(main, [])
+
+react(main)

--- a/docs/examples/disable_redirects.py
+++ b/docs/examples/disable_redirects.py
@@ -4,12 +4,12 @@ from twisted.internet.task import react
 import treq
 
 
-async def main(reactor):
-    response = await treq.get(
+async def disable_redirects(reactor):
+    resp = await treq.get(
         "https://httpbin.org/redirect/1",
         allow_redirects=False,
     )
-    await print_response(response)
+    await print_response(resp)
 
 
-react(main)
+react(disable_redirects)

--- a/docs/examples/download_file.py
+++ b/docs/examples/download_file.py
@@ -3,11 +3,10 @@ from twisted.internet.task import react
 import treq
 
 
-def download_file(reactor, url, destination_filename):
-    destination = open(destination_filename, 'wb')
-    d = treq.get(url, unbuffered=True)
-    d.addCallback(treq.collect, destination.write)
-    d.addBoth(lambda _: destination.close())
-    return d
+async def download_file(reactor, url, destination_filename):
+    with open(destination_filename, "wb") as destination:
+        response = await treq.get(url, unbuffered=True)
+        await treq.collect(response, destination.write)
 
-react(download_file, ['https://httpbin.org/get', 'download.txt'])
+
+react(download_file, ["https://httpbin.org/get", "download.txt"])

--- a/docs/examples/json_post.py
+++ b/docs/examples/json_post.py
@@ -5,7 +5,7 @@ from twisted.internet.task import react
 import treq
 
 
-async def main(reactor):
+async def json_post(reactor):
     response = await treq.post(
         "https://httpbin.org/post",
         json={"msg": "Hello!"},
@@ -14,4 +14,4 @@ async def main(reactor):
     pprint(data)
 
 
-react(main)
+react(json_post)

--- a/docs/examples/json_post.py
+++ b/docs/examples/json_post.py
@@ -1,18 +1,17 @@
 from pprint import pprint
 
-from twisted.internet import defer
 from twisted.internet.task import react
 
 import treq
 
 
-@defer.inlineCallbacks
-def main(reactor):
-    response = yield treq.post(
-        'https://httpbin.org/post',
+async def main(reactor):
+    response = await treq.post(
+        "https://httpbin.org/post",
         json={"msg": "Hello!"},
     )
-    data = yield response.json()
+    data = await response.json()
     pprint(data)
 
-react(main, [])
+
+react(main)

--- a/docs/examples/query_params.py
+++ b/docs/examples/query_params.py
@@ -1,39 +1,42 @@
 from twisted.internet.task import react
-from twisted.internet.defer import inlineCallbacks
 
 import treq
 
 
-@inlineCallbacks
-def main(reactor):
-    print('List of tuples')
-    resp = yield treq.get('https://httpbin.org/get',
-                          params=[('foo', 'bar'), ('baz', 'bax')])
-    content = yield resp.text()
+async def main(reactor):
+    print("List of tuples")
+    resp = await treq.get(
+        "https://httpbin.org/get", params=[("foo", "bar"), ("baz", "bax")]
+    )
+    content = await resp.text()
     print(content)
 
-    print('Single value dictionary')
-    resp = yield treq.get('https://httpbin.org/get',
-                          params={'foo': 'bar', 'baz': 'bax'})
-    content = yield resp.text()
+    print("Single value dictionary")
+    resp = await treq.get(
+        "https://httpbin.org/get", params={"foo": "bar", "baz": "bax"}
+    )
+    content = await resp.text()
     print(content)
 
-    print('Multi value dictionary')
-    resp = yield treq.get('https://httpbin.org/get',
-                          params={b'foo': [b'bar', b'baz', b'bax']})
-    content = yield resp.text()
+    print("Multi value dictionary")
+    resp = await treq.get(
+        "https://httpbin.org/get", params={b"foo": [b"bar", b"baz", b"bax"]}
+    )
+    content = await resp.text()
     print(content)
 
-    print('Mixed value dictionary')
-    resp = yield treq.get('https://httpbin.org/get',
-                          params={'foo': [1, 2, 3], 'bax': b'quux', b'bar': 'foo'})
-    content = yield resp.text()
+    print("Mixed value dictionary")
+    resp = await treq.get(
+        "https://httpbin.org/get",
+        params={"foo": [1, 2, 3], "bax": b"quux", b"bar": "foo"},
+    )
+    content = await resp.text()
     print(content)
 
-    print('Preserved query parameters')
-    resp = yield treq.get('https://httpbin.org/get?foo=bar',
-                          params={'baz': 'bax'})
-    content = yield resp.text()
+    print("Preserved query parameters")
+    resp = await treq.get("https://httpbin.org/get?foo=bar", params={"baz": "bax"})
+    content = await resp.text()
     print(content)
 
-react(main, [])
+
+react(main)

--- a/docs/examples/query_params.py
+++ b/docs/examples/query_params.py
@@ -3,7 +3,7 @@ from twisted.internet.task import react
 import treq
 
 
-async def main(reactor):
+async def query_params(reactor):
     print("List of tuples")
     resp = await treq.get(
         "https://httpbin.org/get", params=[("foo", "bar"), ("baz", "bax")]
@@ -39,4 +39,4 @@ async def main(reactor):
     print(content)
 
 
-react(main)
+react(query_params)

--- a/docs/examples/query_params.py
+++ b/docs/examples/query_params.py
@@ -8,35 +8,30 @@ async def query_params(reactor):
     resp = await treq.get(
         "https://httpbin.org/get", params=[("foo", "bar"), ("baz", "bax")]
     )
-    content = await resp.text()
-    print(content)
+    print(await resp.text())
 
     print("Single value dictionary")
     resp = await treq.get(
         "https://httpbin.org/get", params={"foo": "bar", "baz": "bax"}
     )
-    content = await resp.text()
-    print(content)
+    print(await resp.text())
 
     print("Multi value dictionary")
     resp = await treq.get(
         "https://httpbin.org/get", params={b"foo": [b"bar", b"baz", b"bax"]}
     )
-    content = await resp.text()
-    print(content)
+    print(await resp.text())
 
     print("Mixed value dictionary")
     resp = await treq.get(
         "https://httpbin.org/get",
         params={"foo": [1, 2, 3], "bax": b"quux", b"bar": "foo"},
     )
-    content = await resp.text()
-    print(content)
+    print(await resp.text())
 
     print("Preserved query parameters")
     resp = await treq.get("https://httpbin.org/get?foo=bar", params={"baz": "bax"})
-    content = await resp.text()
-    print(content)
+    print(await resp.text())
 
 
 react(query_params)

--- a/docs/examples/redirects.py
+++ b/docs/examples/redirects.py
@@ -1,12 +1,12 @@
-from twisted.internet.task import react
 from _utils import print_response
+from twisted.internet.task import react
 
 import treq
 
 
-def main(reactor, *args):
-    d = treq.get('https://httpbin.org/redirect/1')
-    d.addCallback(print_response)
-    return d
+async def main(reactor):
+    response = await treq.get("https://httpbin.org/redirect/1")
+    await print_response(response)
 
-react(main, [])
+
+react(main)

--- a/docs/examples/redirects.py
+++ b/docs/examples/redirects.py
@@ -4,9 +4,9 @@ from twisted.internet.task import react
 import treq
 
 
-async def main(reactor):
-    response = await treq.get("https://httpbin.org/redirect/1")
-    await print_response(response)
+async def redirects(reactor):
+    resp = await treq.get("https://httpbin.org/redirect/1")
+    await print_response(resp)
 
 
-react(main)
+react(redirects)

--- a/docs/examples/response_history.py
+++ b/docs/examples/response_history.py
@@ -6,7 +6,6 @@ import treq
 
 async def main(reactor):
     response = await treq.get("https://httpbin.org/redirect/1")
-
     print("Response history:")
     print(response.history())
     await print_response(response)

--- a/docs/examples/response_history.py
+++ b/docs/examples/response_history.py
@@ -4,11 +4,11 @@ from twisted.internet.task import react
 import treq
 
 
-async def main(reactor):
-    response = await treq.get("https://httpbin.org/redirect/1")
+async def response_history(reactor):
+    resp = await treq.get("https://httpbin.org/redirect/1")
     print("Response history:")
-    print(response.history())
-    await print_response(response)
+    print(resp.history())
+    await print_response(resp)
 
 
-react(main)
+react(response_history)

--- a/docs/examples/response_history.py
+++ b/docs/examples/response_history.py
@@ -1,18 +1,15 @@
-from twisted.internet.task import react
 from _utils import print_response
+from twisted.internet.task import react
 
 import treq
 
 
-def main(reactor, *args):
-    d = treq.get('https://httpbin.org/redirect/1')
+async def main(reactor):
+    response = await treq.get("https://httpbin.org/redirect/1")
 
-    def cb(response):
-        print('Response history:')
-        print(response.history())
-        return print_response(response)
+    print("Response history:")
+    print(response.history())
+    await print_response(response)
 
-    d.addCallback(cb)
-    return d
 
-react(main, [])
+react(main)

--- a/docs/examples/using_cookies.py
+++ b/docs/examples/using_cookies.py
@@ -1,5 +1,5 @@
-from twisted.internet.task import react
 from _utils import print_response
+from twisted.internet.task import react
 
 import treq
 

--- a/docs/examples/using_cookies.py
+++ b/docs/examples/using_cookies.py
@@ -4,7 +4,7 @@ from twisted.internet.task import react
 import treq
 
 
-async def main(reactor):
+async def using_cookies(reactor):
     resp = await treq.get("https://httpbin.org/cookies/set?hello=world")
 
     jar = resp.cookies()
@@ -16,4 +16,4 @@ async def main(reactor):
     )
 
 
-react(main)
+react(using_cookies)

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -36,7 +36,7 @@ The high-level :class:`~hyperlink.DecodedURL` form is useful when programaticall
 Here is an example that builds a URL that contains a ``&`` character, which is automatically escaped properly.
 
 .. literalinclude:: examples/basic_url.py
-    :pyobject: main
+    :pyobject: basic_url
 
 Full example: :download:`basic_url.py <examples/basic_url.py>`
 
@@ -55,7 +55,7 @@ Scalar values means `str`, `bytes`, or anything else — even ``None`` — which
 Strings are UTF-8 encoded.
 
 .. literalinclude:: examples/query_params.py
-    :pyobject: main
+    :pyobject: query_params
 
 Full example: :download:`query_params.py <examples/query_params.py>`
 
@@ -73,7 +73,7 @@ The :meth:`_Response.json()` method decodes a JSON response body.
 It buffers the whole response and decodes it with :func:`json.loads()`.
 
 .. literalinclude:: examples/json_post.py
-    :pyobject: main
+    :pyobject: json_post
     :emphasize-lines: 4,6
 
 Full example: :download:`json_post.py <examples/json_post.py>`
@@ -87,7 +87,7 @@ passing an ``auth`` keyword argument to any of the request functions.
 The ``auth`` argument should be a tuple of the form ``('username', 'password')``.
 
 .. literalinclude:: examples/basic_auth.py
-    :pyobject: main
+    :pyobject: basic_auth
     :emphasize-lines: 4
 
 Full example: :download:`basic_auth.py <examples/basic_auth.py>`
@@ -100,7 +100,7 @@ treq handles redirects by default.
 The following will print a 200 OK response.
 
 .. literalinclude:: examples/redirects.py
-    :pyobject: main
+    :pyobject: redirects
 
 Full example: :download:`redirects.py <examples/redirects.py>`
 
@@ -108,7 +108,7 @@ You can easily disable redirects by simply passing `allow_redirects=False` to
 any of the request methods.
 
 .. literalinclude:: examples/disable_redirects.py
-    :pyobject: main
+    :pyobject: disable_redirects
     :emphasize-lines: 4
 
 Full example: :download:`disable_redirects.py <examples/disable_redirects.py>`
@@ -117,7 +117,7 @@ You can even access the complete history of treq response objects by calling
 the :meth:`~treq.response._Response.history()` method on the response.
 
 .. literalinclude:: examples/response_history.py
-    :pyobject: main
+    :pyobject: response_history
     :emphasize-lines: 4
 
 Full example: :download:`response_history.py <examples/response_history.py>`
@@ -132,7 +132,7 @@ Any cookies set by the server can be retrieved using the :py:meth:`~treq.respons
 Use :py:func:`treq.cookies.search()` to extract cookies from the jar:
 
 .. literalinclude:: examples/using_cookies.py
-    :pyobject: main
+    :pyobject: using_cookies
     :emphasize-lines: 4-5
 
 Full example: :download:`using_cookies.py <examples/using_cookies.py>`
@@ -151,7 +151,7 @@ Internally, the :py:class:`~treq.client.HTTPClient` wraps an instance of
 behavior.
 
 .. literalinclude:: examples/custom_agent.py
-    :pyobject: main
+    :pyobject: custom_agent
     :emphasize-lines: 2-3
 
 Full example: :download:`custom_agent.py <examples/custom_agent.py>`

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -12,12 +12,14 @@ data available from the response.  Much like :meth:`IProtocol.dataReceived`,
 :py:func:`treq.collect` knows nothing about the framing of your data and will
 simply call your collector function with any data that is currently available.
 
+By default, treq buffers the full response in memory.
+Pass ``unbufferred=True`` to disable this behavior.
+
 Here is an example which simply a file object's write method to
 :py:func:`treq.collect` to save the response body to a file.
 
 .. literalinclude:: examples/download_file.py
-    :linenos:
-    :lines: 6-11
+   :pyobject: download_file
 
 Full example: :download:`download_file.py <examples/download_file.py>`
 
@@ -34,7 +36,6 @@ The high-level :class:`~hyperlink.DecodedURL` form is useful when programaticall
 Here is an example that builds a URL that contains a ``&`` character, which is automatically escaped properly.
 
 .. literalinclude:: examples/basic_url.py
-    :linenos:
     :pyobject: main
 
 Full example: :download:`basic_url.py <examples/basic_url.py>`
@@ -50,17 +51,16 @@ The ``params`` argument may be either a ``dict`` or a ``list`` of
 ``(key, value)`` tuples.
 
 If it is a ``dict`` then the values in the dict may either be scalar values or a ``list`` or ``tuple`` thereof.
-Scalar values means ``str``, ``bytes``, or anything else — even ``None`` — which will be coerced to ``str``.
+Scalar values means `str`, `bytes`, or anything else — even ``None`` — which will be coerced to `str`.
 Strings are UTF-8 encoded.
 
 .. literalinclude:: examples/query_params.py
-    :linenos:
-    :lines: 7-37
+    :pyobject: main
 
 Full example: :download:`query_params.py <examples/query_params.py>`
 
 If you prefer a strictly-typed API, try :class:`hyperlink.DecodedURL`.
-Use its :meth:`~hyperlink.URL.add` and :meth:`~hyperlink.URL.set` methods to add query parameters without risk of accidental type coercion.
+Its :meth:`~hyperlink.URL.add` and :meth:`~hyperlink.URL.set` methods manipulate query parameters without risk of accidental type coercion.
 
 JSON
 ----
@@ -73,8 +73,8 @@ The :meth:`_Response.json()` method decodes a JSON response body.
 It buffers the whole response and decodes it with :func:`json.loads()`.
 
 .. literalinclude:: examples/json_post.py
-    :linenos:
     :pyobject: main
+    :emphasize-lines: 4,6
 
 Full example: :download:`json_post.py <examples/json_post.py>`
 
@@ -87,8 +87,8 @@ passing an ``auth`` keyword argument to any of the request functions.
 The ``auth`` argument should be a tuple of the form ``('username', 'password')``.
 
 .. literalinclude:: examples/basic_auth.py
-    :linenos:
-    :lines: 7-15
+    :pyobject: main
+    :emphasize-lines: 4
 
 Full example: :download:`basic_auth.py <examples/basic_auth.py>`
 
@@ -100,8 +100,7 @@ treq handles redirects by default.
 The following will print a 200 OK response.
 
 .. literalinclude:: examples/redirects.py
-    :linenos:
-    :lines: 7-12
+    :pyobject: main
 
 Full example: :download:`redirects.py <examples/redirects.py>`
 
@@ -109,8 +108,8 @@ You can easily disable redirects by simply passing `allow_redirects=False` to
 any of the request methods.
 
 .. literalinclude:: examples/disable_redirects.py
-    :linenos:
-    :lines: 7-12
+    :pyobject: main
+    :emphasize-lines: 4
 
 Full example: :download:`disable_redirects.py <examples/disable_redirects.py>`
 
@@ -118,8 +117,8 @@ You can even access the complete history of treq response objects by calling
 the :meth:`~treq.response._Response.history()` method on the response.
 
 .. literalinclude:: examples/response_history.py
-    :linenos:
     :pyobject: main
+    :emphasize-lines: 4
 
 Full example: :download:`response_history.py <examples/response_history.py>`
 
@@ -127,16 +126,14 @@ Full example: :download:`response_history.py <examples/response_history.py>`
 Cookies
 -------
 
-Cookies can be set by passing a ``dict`` or ``cookielib.CookieJar`` instance
-via the ``cookies`` keyword argument.  Later cookies set by the server can be
-retrieved using the :py:meth:`~treq.response._Response.cookies()` method of the response.
+Cookies can be set by passing a ``dict`` or ``cookielib.CookieJar`` instance via the ``cookies`` keyword argument.
+Any cookies set by the server can be retrieved using the :py:meth:`~treq.response._Response.cookies()` response method, which returns a :py:class:`~http.cookiejar.CookieJar`.
 
-The object returned by :py:meth:`~treq.response._Response.cookies()` supports the same key/value
-access as `requests cookies <https://requests.readthedocs.io/en/latest/user/quickstart/#cookies>`_.
+Use :py:func:`treq.cookies.search()` to extract cookies from the jar:
 
 .. literalinclude:: examples/using_cookies.py
-    :linenos:
     :pyobject: main
+    :emphasize-lines: 4-5
 
 Full example: :download:`using_cookies.py <examples/using_cookies.py>`
 
@@ -154,7 +151,7 @@ Internally, the :py:class:`~treq.client.HTTPClient` wraps an instance of
 behavior.
 
 .. literalinclude:: examples/custom_agent.py
-    :linenos:
-    :lines: 6-19
+    :pyobject: main
+    :emphasize-lines: 2-3
 
 Full example: :download:`custom_agent.py <examples/custom_agent.py>`

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -136,7 +136,7 @@ access as `requests cookies <https://requests.readthedocs.io/en/latest/user/quic
 
 .. literalinclude:: examples/using_cookies.py
     :linenos:
-    :lines: 7-20
+    :pyobject: main
 
 Full example: :download:`using_cookies.py <examples/using_cookies.py>`
 

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -126,7 +126,7 @@ Full example: :download:`response_history.py <examples/response_history.py>`
 Cookies
 -------
 
-Cookies can be set by passing a ``dict`` or ``cookielib.CookieJar`` instance via the ``cookies`` keyword argument.
+Cookies can be set by passing a `dict` or :py:class:`http.cookiejar.CookieJar` instance via the *cookies* keyword argument.
 Any cookies set by the server can be retrieved using the :py:meth:`~treq.response._Response.cookies()` response method, which returns a :py:class:`~http.cookiejar.CookieJar`.
 
 Use :py:func:`treq.cookies.search()` to extract cookies from the jar:

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -119,7 +119,7 @@ the :meth:`~treq.response._Response.history()` method on the response.
 
 .. literalinclude:: examples/response_history.py
     :linenos:
-    :lines: 7-15
+    :pyobject: main
 
 Full example: :download:`response_history.py <examples/response_history.py>`
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ GET
 +++
 
 .. literalinclude:: examples/basic_get.py
-    :pyobject: main
+    :pyobject: basic_get
 
 Full example: :download:`basic_get.py <examples/basic_get.py>`
 
@@ -37,7 +37,7 @@ POST
 ++++
 
 .. literalinclude:: examples/basic_post.py
-    :pyobject: main
+    :pyobject: basic_post
 
 Full example: :download:`basic_post.py <examples/basic_post.py>`
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ treq: High-level Twisted HTTP Client API
 
 Release v\ |release| (:doc:`What's new? <changelog>`).
 
-`treq <https://pypi.org/project/treq>`_ depends on a recent Twisted and functions on Python 2.7 and Python 3.3+ (including PyPy).
+`treq <https://pypi.org/project/treq>`_ depends on a recent Twisted and a `supported version of CPython <https://devguide.python.org/versions/#versions>`_ or `PyPy <https://pypy.org/download.html>`_.
 
 Why?
 ----
@@ -13,8 +13,8 @@ I want the same ease of use when writing Twisted applications.
 treq is not of course a perfect clone of `requests`_.
 I have tried to stay true to the do-what-I-mean spirit of the `requests`_ API and also kept the API familiar to users of `Twisted`_ and :class:`twisted.web.client.Agent` on which treq is based.
 
-.. _requests: https://requests.readthedocs.io/en/master/
-.. _Twisted: https://twistedmatrix.com/
+.. _requests: https://requests.readthedocs.io/en/latest/
+.. _Twisted: https://www.twistedmatrix.com
 
 Quick Start
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
 ]
 docs = [
     "sphinx",
+    "sphinx_rtd_theme",
 ]
 
 [project.urls]

--- a/src/treq/testing.py
+++ b/src/treq/testing.py
@@ -429,16 +429,6 @@ class RequestSequence:
     :class:`~twisted.trial.unittest.SynchronousTestCase`) will translate into
     a test failure.
 
-    .. note::
-
-        Some versions of
-        :class:`twisted.trial.unittest.SynchronousTestCase` report
-        logged errors on the wrong test: see `Twisted #9267
-        <https://twistedmatrix.com/trac/ticket/9267>`_.
-
-    ..  TODO Update the above note to say what version of
-        SynchronousTestCase is fixed once Twisted >17.5.0 is released.
-
     When not subclassing Trial's classes you must pass `async_failure_reporter`
     and implement equivalent behavior or errors will pass silently. For
     example::

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
 python = python3.12
 skip_install = True
 deps = flake8
-commands = flake8 src/treq/
+commands = flake8 src/treq/ docs/examples/
 
 [testenv:towncrier]
 python = python3.12


### PR DESCRIPTION
- [x] Switch to the RTD Sphinx theme
  - [x] Set `flyout_display = 'attached'` ([ref](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#confval-flyout_display))
  - [x] [Set a canonical URL](https://docs.readthedocs.com/platform/stable/intro/sphinx.html#set-the-canonical-url)
  - [x] [Configure search](https://docs.readthedocs.com/platform/stable/intro/sphinx.html#configure-read-the-docs-search)
- [x] Rewrite examples to use `async/await`
- [ ] ~Display example output in the docs~