### PR TITLE
[Issue-412]: use self.body for setting _SynchronousProducer length attribute

### DIFF
--- a/src/treq/test/test_testing.py
+++ b/src/treq/test/test_testing.py
@@ -19,7 +19,8 @@ from treq.testing import (
     HasHeaders,
     RequestSequence,
     StringStubbingResource,
-    StubTreq
+    StubTreq,
+    _SynchronousProducer
 )
 
 
@@ -623,3 +624,17 @@ class RequestSequenceTests(TestCase):
 
         [failure] = self.flushLoggedErrors()
         self.assertIsInstance(failure.value, AssertionError)
+
+    def test_synchronous_producer_length_matches_body_length(self):
+       # bytes input
+       p = _SynchronousProducer(b"abc")
+       self.assertEqual(p.length, 3)
+
+        # str input (should be encoded to utf-8)
+       p2 = _SynchronousProducer("abc")
+       self.assertEqual(p2.length, 3)
+
+        # str with non-ascii
+       p3 = _SynchronousProducer("ü")
+       self.assertEqual(p3.length, len("ü".encode("utf-8")))
+

--- a/src/treq/test/test_testing.py
+++ b/src/treq/test/test_testing.py
@@ -1,6 +1,7 @@
 """
 In-memory treq returns stubbed responses.
 """
+
 from functools import partial
 from inspect import getmembers, isfunction
 from json import dumps
@@ -20,12 +21,13 @@ from treq.testing import (
     RequestSequence,
     StringStubbingResource,
     StubTreq,
-    _SynchronousProducer
+    _SynchronousProducer,
 )
 
 
 class _StaticTestResource(Resource):
     """Resource that always returns 418 "I'm a teapot"""
+
     isLeaf = True
 
     def render(self, request):
@@ -38,24 +40,23 @@ class _RedirectResource(Resource):
     """
     Resource that redirects to a different domain.
     """
+
     isLeaf = True
 
     def render(self, request):
-        if b'redirected' not in request.uri:
-            request.redirect(b'https://example.org/redirected')
+        if b"redirected" not in request.uri:
+            request.redirect(b"https://example.org/redirected")
         return dumps(
             {
-                key.decode("charmap"): [
-                    value.decode("charmap")
-                    for value in values
-                ]
-                for key, values in
-                request.requestHeaders.getAllRawHeaders()}
+                key.decode("charmap"): [value.decode("charmap") for value in values]
+                for key, values in request.requestHeaders.getAllRawHeaders()
+            }
         ).encode("utf-8")
 
 
 class _NonResponsiveTestResource(Resource):
     """Resource that returns NOT_DONE_YET and never finishes the request"""
+
     isLeaf = True
 
     def render(self, request):
@@ -67,6 +68,7 @@ class _EventuallyResponsiveTestResource(Resource):
     Resource that returns NOT_DONE_YET and stores the request so that something
     else can finish the response later.
     """
+
     isLeaf = True
 
     def render(self, request):
@@ -78,6 +80,7 @@ class _SessionIdTestResource(Resource):
     """
     Resource that returns the current session ID.
     """
+
     isLeaf = True
 
     def __init__(self):
@@ -106,56 +109,64 @@ class StubbingTests(TestCase):
     """
     Tests for :class:`StubTreq`.
     """
+
     def test_stubtreq_provides_all_functions_in_treq_all(self):
         """
         Every single function and attribute exposed by :obj:`treq.__all__` is
         provided by :obj:`StubTreq`.
         """
-        treq_things = [(name, obj) for name, obj in getmembers(treq)
-                       if name in treq.__all__]
+        treq_things = [
+            (name, obj) for name, obj in getmembers(treq) if name in treq.__all__
+        ]
         stub = StubTreq(_StaticTestResource())
 
-        api_things = [(name, obj) for name, obj in treq_things
-                      if obj.__module__ == "treq.api"]
-        content_things = [(name, obj) for name, obj in treq_things
-                          if obj.__module__ == "treq.content"]
+        api_things = [
+            (name, obj) for name, obj in treq_things if obj.__module__ == "treq.api"
+        ]
+        content_things = [
+            (name, obj) for name, obj in treq_things if obj.__module__ == "treq.content"
+        ]
 
         # sanity checks - this test should fail if treq exposes a new API
         # without changes being made to StubTreq and this test.
-        msg = ("At the time this test was written, StubTreq only knew about "
-               "treq exposing functions from treq.api and treq.content.  If "
-               "this has changed, StubTreq will need to be updated, as will "
-               "this test.")
+        msg = (
+            "At the time this test was written, StubTreq only knew about "
+            "treq exposing functions from treq.api and treq.content.  If "
+            "this has changed, StubTreq will need to be updated, as will "
+            "this test."
+        )
         self.assertTrue(all(isfunction(obj) for name, obj in treq_things), msg)
-        self.assertEqual(set(treq_things), set(api_things + content_things),
-                         msg)
+        self.assertEqual(set(treq_things), set(api_things + content_things), msg)
 
         for name, obj in api_things:
             self.assertTrue(
                 isfunction(getattr(stub, name, None)),
-                "StubTreq.{0} should be a function.".format(name))
+                "StubTreq.{0} should be a function.".format(name),
+            )
 
         for name, obj in content_things:
             self.assertIs(
-                getattr(stub, name, None), obj,
-                "StubTreq.{0} should just expose treq.{0}".format(name))
+                getattr(stub, name, None),
+                obj,
+                "StubTreq.{0} should just expose treq.{0}".format(name),
+            )
 
     def test_providing_resource_to_stub_treq(self):
         """
         The resource provided to StubTreq responds to every request no
         matter what the URI or parameters or data.
         """
-        verbs = ('GET', 'PUT', 'HEAD', 'PATCH', 'DELETE', 'POST')
+        verbs = ("GET", "PUT", "HEAD", "PATCH", "DELETE", "POST")
         urls = (
-            'http://supports-http.com',
-            'https://supports-https.com',
-            'http://this/has/a/path/and/invalid/domain/name',
-            'https://supports-https.com:8080',
-            'http://supports-http.com:8080',
+            "http://supports-http.com",
+            "https://supports-https.com",
+            "http://this/has/a/path/and/invalid/domain/name",
+            "https://supports-https.com:8080",
+            "http://supports-http.com:8080",
         )
-        params = (None, {}, {b'page': [1]})
-        headers = (None, {}, {b'x-random-header': [b'value', b'value2']})
-        data = (None, b"", b'some data', b'{"some": "json"}')
+        params = (None, {}, {b"page": [1]})
+        headers = (None, {}, {b"x-random-header": [b"value", b"value2"]})
+        data = (None, b"", b"some data", b'{"some": "json"}')
 
         stub = StubTreq(_StaticTestResource())
 
@@ -169,15 +180,18 @@ class StubbingTests(TestCase):
         )
         for combo in combos:
             verb, kwargs = combo
-            deferreds = (stub.request(verb, **kwargs),
-                         getattr(stub, verb.lower())(**kwargs))
+            deferreds = (
+                stub.request(verb, **kwargs),
+                getattr(stub, verb.lower())(**kwargs),
+            )
             for d in deferreds:
                 resp = self.successResultOf(d)
                 self.assertEqual(418, resp.code)
-                self.assertEqual([b'teapot!'],
-                                 resp.headers.getRawHeaders(b'x-teapot'))
-                self.assertEqual(b"" if verb == "HEAD" else b"I'm a teapot",
-                                 self.successResultOf(stub.content(resp)))
+                self.assertEqual([b"teapot!"], resp.headers.getRawHeaders(b"x-teapot"))
+                self.assertEqual(
+                    b"" if verb == "HEAD" else b"I'm a teapot",
+                    self.successResultOf(stub.content(resp)),
+                )
 
     def test_handles_invalid_schemes(self):
         """
@@ -196,8 +210,8 @@ class StubbingTests(TestCase):
         """
         stub = StubTreq(_StaticTestResource())
         self.assertRaises(
-            AssertionError, stub.request,
-            'method', 'http://url', files=b'some file')
+            AssertionError, stub.request, "method", "http://url", files=b"some file"
+        )
 
     def test_passing_in_strange_data_is_rejected(self):
         """
@@ -205,15 +219,13 @@ class StubbingTests(TestCase):
         """
         stub = StubTreq(_StaticTestResource())
         self.assertRaises(
-            AssertionError, stub.request, 'method', 'http://url',
-            data=object())
-        self.successResultOf(stub.request('method', 'http://url', data={}))
-        self.successResultOf(stub.request('method', 'http://url', data=[]))
-        self.successResultOf(stub.request('method', 'http://url', data=()))
-        self.successResultOf(
-            stub.request('method', 'http://url', data=b""))
-        self.successResultOf(
-            stub.request('method', 'http://url', data=""))
+            AssertionError, stub.request, "method", "http://url", data=object()
+        )
+        self.successResultOf(stub.request("method", "http://url", data={}))
+        self.successResultOf(stub.request("method", "http://url", data=[]))
+        self.successResultOf(stub.request("method", "http://url", data=()))
+        self.successResultOf(stub.request("method", "http://url", data=b""))
+        self.successResultOf(stub.request("method", "http://url", data=""))
 
     def test_handles_failing_asynchronous_requests(self):
         """
@@ -221,7 +233,7 @@ class StubbingTests(TestCase):
         request.
         """
         stub = StubTreq(_NonResponsiveTestResource())
-        d = stub.request('method', 'http://url', data=b"1234")
+        d = stub.request("method", "http://url", data=b"1234")
         self.assertNoResult(d)
         d.cancel()
         self.failureResultOf(d, ResponseFailed)
@@ -233,7 +245,7 @@ class StubbingTests(TestCase):
         """
         rsrc = _EventuallyResponsiveTestResource()
         stub = StubTreq(rsrc)
-        d = stub.request('method', 'http://example.com/', data=b"1234")
+        d = stub.request("method", "http://example.com/", data=b"1234")
         self.assertNoResult(d)
         rsrc.stored_request.finish()
         stub.flush()
@@ -247,17 +259,17 @@ class StubbingTests(TestCase):
         """
         rsrc = _EventuallyResponsiveTestResource()
         stub = StubTreq(rsrc)
-        d = stub.request('method', 'http://example.com/', data=b"1234")
+        d = stub.request("method", "http://example.com/", data=b"1234")
         self.assertNoResult(d)
 
         chunks = []
-        rsrc.stored_request.write(b'spam ')
-        rsrc.stored_request.write(b'eggs')
+        rsrc.stored_request.write(b"spam ")
+        rsrc.stored_request.write(b"eggs")
         stub.flush()
         resp = self.successResultOf(d)
         d = stub.collect(resp, chunks.append)
         self.assertNoResult(d)
-        self.assertEqual(b''.join(chunks), b'spam eggs')
+        self.assertEqual(b"".join(chunks), b"spam eggs")
 
         rsrc.stored_request.finish()
         stub.flush()
@@ -270,23 +282,23 @@ class StubbingTests(TestCase):
         """
         rsrc = _EventuallyResponsiveTestResource()
         stub = StubTreq(rsrc)
-        d = stub.request('method', 'http://example.com/', data="1234")
+        d = stub.request("method", "http://example.com/", data="1234")
         self.assertNoResult(d)
 
         chunks = []
-        rsrc.stored_request.write(b'spam ')
-        rsrc.stored_request.write(b'eggs')
+        rsrc.stored_request.write(b"spam ")
+        rsrc.stored_request.write(b"eggs")
         stub.flush()
         resp = self.successResultOf(d)
         d = stub.collect(resp, chunks.append)
         self.assertNoResult(d)
-        self.assertEqual(b''.join(chunks), b'spam eggs')
+        self.assertEqual(b"".join(chunks), b"spam eggs")
 
         del chunks[:]
-        rsrc.stored_request.write(b'eggs\r\nspam\r\n')
+        rsrc.stored_request.write(b"eggs\r\nspam\r\n")
         stub.flush()
         self.assertNoResult(d)
-        self.assertEqual(b''.join(chunks), b'eggs\r\nspam\r\n')
+        self.assertEqual(b"".join(chunks), b"eggs\r\nspam\r\n")
 
         rsrc.stored_request.finish()
         stub.flush()
@@ -339,12 +351,11 @@ class StubbingTests(TestCase):
         rsrc = _RedirectResource()
         stub = StubTreq(rsrc)
         d = stub.request(
-            "GET", "http://example.com/",
-            cookies={"not-across-redirect": "nope"}
+            "GET", "http://example.com/", cookies={"not-across-redirect": "nope"}
         )
         resp = self.successResultOf(d)
         received = self.successResultOf(resp.json())
-        self.assertNotIn('not-across-redirect', received.get('Cookie', [''])[0])
+        self.assertNotIn("not-across-redirect", received.get("Cookie", [""])[0])
 
     def test_cookies_sent_for_same_domain(self):
         """
@@ -357,12 +368,11 @@ class StubbingTests(TestCase):
         rsrc = _RedirectResource()
         stub = StubTreq(rsrc)
         d = stub.request(
-            "GET", "https://example.org/",
-            cookies={'sent-to-same-domain': 'yes'}
+            "GET", "https://example.org/", cookies={"sent-to-same-domain": "yes"}
         )
         resp = self.successResultOf(d)
         received = self.successResultOf(resp.json())
-        self.assertIn('sent-to-same-domain', received.get('Cookie', [''])[0])
+        self.assertIn("sent-to-same-domain", received.get("Cookie", [""])[0])
 
     def test_cookies_sent_with_explicit_port(self):
         """
@@ -375,38 +385,44 @@ class StubbingTests(TestCase):
         stub = StubTreq(rsrc)
 
         d = stub.request(
-            "GET", "http://example.org:8080/redirected",
-            cookies={'sent-to-non-default-port': 'yes'}
+            "GET",
+            "http://example.org:8080/redirected",
+            cookies={"sent-to-non-default-port": "yes"},
         )
         resp = self.successResultOf(d)
         received = self.successResultOf(resp.json())
-        self.assertIn('sent-to-non-default-port', received.get('Cookie', [''])[0])
+        self.assertIn("sent-to-non-default-port", received.get("Cookie", [""])[0])
 
         d = stub.request(
-            "GET", "https://example.org:8443/redirected",
-            cookies={'sent-to-non-default-port': 'yes'}
+            "GET",
+            "https://example.org:8443/redirected",
+            cookies={"sent-to-non-default-port": "yes"},
         )
         resp = self.successResultOf(d)
         received = self.successResultOf(resp.json())
-        self.assertIn('sent-to-non-default-port', received.get('Cookie', [''])[0])
+        self.assertIn("sent-to-non-default-port", received.get("Cookie", [""])[0])
 
 
 class HasHeadersTests(TestCase):
     """
     Tests for :obj:`HasHeaders`.
     """
+
     def test_equality_and_strict_subsets_succeed(self):
         """
         The :obj:`HasHeaders` returns True if both sets of headers are
         equivalent, or the first is a strict subset of the second.
         """
-        self.assertEqual(HasHeaders({'one': ['two', 'three']}),
-                         {'one': ['two', 'three']},
-                         "Equivalent headers do not match.")
-        self.assertEqual(HasHeaders({'one': ['two', 'three']}),
-                         {'one': ['two', 'three', 'four'],
-                          'ten': ['six']},
-                         "Strict subset headers do not match")
+        self.assertEqual(
+            HasHeaders({"one": ["two", "three"]}),
+            {"one": ["two", "three"]},
+            "Equivalent headers do not match.",
+        )
+        self.assertEqual(
+            HasHeaders({"one": ["two", "three"]}),
+            {"one": ["two", "three", "four"], "ten": ["six"]},
+            "Strict subset headers do not match",
+        )
 
     def test_partial_or_zero_intersection_subsets_fail(self):
         """
@@ -414,39 +430,46 @@ class HasHeadersTests(TestCase):
         but the first is not a strict subset of the second.  It also returns
         False if there is no overlap.
         """
-        self.assertNotEqual(HasHeaders({'one': ['two', 'three']}),
-                            {'one': ['three', 'four']},
-                            "Partial value overlap matches")
-        self.assertNotEqual(HasHeaders({'one': ['two', 'three']}),
-                            {'one': ['two']},
-                            "Missing value matches")
-        self.assertNotEqual(HasHeaders({'one': ['two', 'three']}),
-                            {'ten': ['six']},
-                            "Complete inequality matches")
+        self.assertNotEqual(
+            HasHeaders({"one": ["two", "three"]}),
+            {"one": ["three", "four"]},
+            "Partial value overlap matches",
+        )
+        self.assertNotEqual(
+            HasHeaders({"one": ["two", "three"]}),
+            {"one": ["two"]},
+            "Missing value matches",
+        )
+        self.assertNotEqual(
+            HasHeaders({"one": ["two", "three"]}),
+            {"ten": ["six"]},
+            "Complete inequality matches",
+        )
 
     def test_case_insensitive_keys(self):
         """
         The :obj:`HasHeaders` equality function ignores the case of the header
         keys.
         """
-        self.assertEqual(HasHeaders({b'A': [b'1'], b'b': [b'2']}),
-                         {b'a': [b'1'], b'B': [b'2']})
+        self.assertEqual(
+            HasHeaders({b"A": [b"1"], b"b": [b"2"]}), {b"a": [b"1"], b"B": [b"2"]}
+        )
 
     def test_case_sensitive_values(self):
         """
         The :obj:`HasHeaders` equality function does care about the case of
         the header value.
         """
-        self.assertNotEqual(HasHeaders({b'a': [b'a']}), {b'a': [b'A']})
+        self.assertNotEqual(HasHeaders({b"a": [b"a"]}), {b"a": [b"A"]})
 
     def test_bytes_encoded_forms(self):
         """
         The :obj:`HasHeaders` equality function compares the bytes-encoded
         forms of both sets of headers.
         """
-        self.assertEqual(HasHeaders({b'a': [b'a']}), {u'a': [u'a']})
+        self.assertEqual(HasHeaders({b"a": [b"a"]}), {"a": ["a"]})
 
-        self.assertEqual(HasHeaders({u'b': [u'b']}), {b'b': [b'b']})
+        self.assertEqual(HasHeaders({"b": ["b"]}), {b"b": [b"b"]})
 
     def test_repr(self):
         """
@@ -462,6 +485,7 @@ class StringStubbingTests(TestCase):
     """
     Tests for :obj:`StringStubbingResource`.
     """
+
     def _get_response_for(self, expected_args, response):
         """
         Make a :obj:`IStringResponseStubs` that checks the expected args and
@@ -470,8 +494,9 @@ class StringStubbingTests(TestCase):
         method, url, params, headers, data = expected_args
 
         def get_response_for(_method, _url, _params, _headers, _data):
-            self.assertEqual((method, url, params, data),
-                             (_method, _url, _params, _data))
+            self.assertEqual(
+                (method, url, params, data), (_method, _url, _params, _data)
+            )
             self.assertEqual(HasHeaders(headers), _headers)
             return response
 
@@ -482,27 +507,38 @@ class StringStubbingTests(TestCase):
         The :obj:`IStringResponseStubs` is passed the correct parameters with
         which to evaluate the response, and the response is returned.
         """
-        resource = StringStubbingResource(self._get_response_for(
-            (b'DELETE', 'http://what/a/thing', {b'page': [b'1']},
-             {b'x-header': [b'eh']}, b'datastr'),
-            (418, {b'x-response': b'responseheader'}, b'response body')))
+        resource = StringStubbingResource(
+            self._get_response_for(
+                (
+                    b"DELETE",
+                    "http://what/a/thing",
+                    {b"page": [b"1"]},
+                    {b"x-header": [b"eh"]},
+                    b"datastr",
+                ),
+                (418, {b"x-response": b"responseheader"}, b"response body"),
+            )
+        )
 
         stub = StubTreq(resource)
 
-        d = stub.delete('http://what/a/thing', headers={b'x-header': b'eh'},
-                        params={b'page': b'1'}, data=b'datastr')
+        d = stub.delete(
+            "http://what/a/thing",
+            headers={b"x-header": b"eh"},
+            params={b"page": b"1"},
+            data=b"datastr",
+        )
         resp = self.successResultOf(d)
         self.assertEqual(418, resp.code)
-        self.assertEqual([b'responseheader'],
-                         resp.headers.getRawHeaders(b'x-response'))
-        self.assertEqual(b'response body',
-                         self.successResultOf(stub.content(resp)))
+        self.assertEqual([b"responseheader"], resp.headers.getRawHeaders(b"x-response"))
+        self.assertEqual(b"response body", self.successResultOf(stub.content(resp)))
 
 
 class RequestSequenceTests(TestCase):
     """
     Tests for :obj:`RequestSequence`.
     """
+
     def setUp(self):
         """
         Set up a way to report failures asynchronously.
@@ -515,29 +551,46 @@ class RequestSequenceTests(TestCase):
         causes a failure.
         """
         sequence = RequestSequence(
-            [((b'get', 'https://anything/', {b'1': [b'2']},
-               HasHeaders({b'1': [b'1']}), b'what'),
-              (418, {}, b'body')),
-             ((b'get', 'http://anything', {},
-               HasHeaders({b'2': [b'1']}), b'what'),
-              (202, {}, b'deleted'))],
-            async_failure_reporter=self.async_failures.append)
+            [
+                (
+                    (
+                        b"get",
+                        "https://anything/",
+                        {b"1": [b"2"]},
+                        HasHeaders({b"1": [b"1"]}),
+                        b"what",
+                    ),
+                    (418, {}, b"body"),
+                ),
+                (
+                    (
+                        b"get",
+                        "http://anything",
+                        {},
+                        HasHeaders({b"2": [b"1"]}),
+                        b"what",
+                    ),
+                    (202, {}, b"deleted"),
+                ),
+            ],
+            async_failure_reporter=self.async_failures.append,
+        )
 
         stub = StubTreq(StringStubbingResource(sequence))
-        get = partial(stub.get, 'https://anything?1=2', data=b'what',
-                      headers={b'1': b'1'})
+        get = partial(
+            stub.get, "https://anything?1=2", data=b"what", headers={b"1": b"1"}
+        )
 
         resp = self.successResultOf(get())
 
         self.assertEqual(418, resp.code)
-        self.assertEqual(b'body', self.successResultOf(stub.content(resp)))
+        self.assertEqual(b"body", self.successResultOf(stub.content(resp)))
         self.assertEqual([], self.async_failures)
 
         resp = self.successResultOf(get())
         self.assertEqual(500, resp.code)
         self.assertEqual(1, len(self.async_failures))
-        self.assertIn("Expected the next request to be",
-                      self.async_failures[0])
+        self.assertIn("Expected the next request to be", self.async_failures[0])
 
         self.assertFalse(sequence.consumed())
 
@@ -547,17 +600,15 @@ class RequestSequenceTests(TestCase):
         failure.
         """
         sequence = RequestSequence(
-            [],
-            async_failure_reporter=self.async_failures.append)
+            [], async_failure_reporter=self.async_failures.append
+        )
         stub = StubTreq(StringStubbingResource(sequence))
-        d = stub.get('https://anything', data=b'what', headers={b'1': b'1'})
+        d = stub.get("https://anything", data=b"what", headers={b"1": b"1"})
         resp = self.successResultOf(d)
         self.assertEqual(500, resp.code)
-        self.assertEqual(b'StubbingError',
-                         self.successResultOf(resp.content()))
+        self.assertEqual(b"StubbingError", self.successResultOf(resp.content()))
         self.assertEqual(1, len(self.async_failures))
-        self.assertIn("No more requests expected, but request",
-                      self.async_failures[0])
+        self.assertIn("No more requests expected, but request", self.async_failures[0])
 
         # the expected requests have all been made
         self.assertTrue(sequence.consumed())
@@ -567,16 +618,16 @@ class RequestSequenceTests(TestCase):
         :obj:`mock.ANY` can be used with the request parameters.
         """
         sequence = RequestSequence(
-            [((ANY, ANY, ANY, ANY, ANY), (418, {}, b'body'))],
-            async_failure_reporter=self.async_failures.append)
+            [((ANY, ANY, ANY, ANY, ANY), (418, {}, b"body"))],
+            async_failure_reporter=self.async_failures.append,
+        )
         stub = StubTreq(StringStubbingResource(sequence))
 
         with sequence.consume(sync_failure_reporter=self.fail):
-            d = stub.get('https://anything', data=b'what',
-                         headers={b'1': b'1'})
+            d = stub.get("https://anything", data=b"what", headers={b"1": b"1"})
             resp = self.successResultOf(d)
             self.assertEqual(418, resp.code)
-            self.assertEqual(b'body', self.successResultOf(stub.content(resp)))
+            self.assertEqual(b"body", self.successResultOf(stub.content(resp)))
 
         self.assertEqual([], self.async_failures)
 
@@ -589,24 +640,27 @@ class RequestSequenceTests(TestCase):
         expecting requests, the test case will be failed.
         """
         sequence = RequestSequence(
-            [((ANY, ANY, ANY, ANY, ANY), (418, {}, b'body'))] * 2,
-            async_failure_reporter=self.async_failures.append)
+            [((ANY, ANY, ANY, ANY, ANY), (418, {}, b"body"))] * 2,
+            async_failure_reporter=self.async_failures.append,
+        )
         stub = StubTreq(StringStubbingResource(sequence))
 
         consume_failures = []
         with sequence.consume(sync_failure_reporter=consume_failures.append):
 
-            self.successResultOf(stub.get('https://anything', data=b'what',
-                                          headers={b'1': b'1'}))
+            self.successResultOf(
+                stub.get("https://anything", data=b"what", headers={b"1": b"1"})
+            )
 
         self.assertEqual(1, len(consume_failures))
         self.assertIn(
             "Not all expected requests were made.  Still expecting:",
-            consume_failures[0])
+            consume_failures[0],
+        )
         self.assertIn(
-            "{0}(url={0}, params={0}, headers={0}, data={0})".format(
-                repr(ANY)),
-            consume_failures[0])
+            "{0}(url={0}, params={0}, headers={0}, data={0})".format(repr(ANY)),
+            consume_failures[0],
+        )
 
         # no asynchronous failures (mismatches, etc.)
         self.assertEqual([], self.async_failures)
@@ -620,21 +674,20 @@ class RequestSequenceTests(TestCase):
         stub = StubTreq(StringStubbingResource(sequence))
 
         with sequence.consume(self.fail):
-            self.successResultOf(stub.get('https://example.com'))
+            self.successResultOf(stub.get("https://example.com"))
 
         [failure] = self.flushLoggedErrors()
         self.assertIsInstance(failure.value, AssertionError)
 
     def test_synchronous_producer_length_matches_body_length(self):
-       # bytes input
-       p = _SynchronousProducer(b"abc")
-       self.assertEqual(p.length, 3)
+        # bytes input
+        p = _SynchronousProducer(b"abc")
+        self.assertEqual(p.length, 3)
 
         # str input (should be encoded to utf-8)
-       p2 = _SynchronousProducer("abc")
-       self.assertEqual(p2.length, 3)
+        p2 = _SynchronousProducer("abc")
+        self.assertEqual(p2.length, 3)
 
         # str with non-ascii
-       p3 = _SynchronousProducer("ü")
-       self.assertEqual(p3.length, len("ü".encode("utf-8")))
-
+        p3 = _SynchronousProducer("ü")
+        self.assertEqual(p3.length, len("ü".encode("utf-8")))

--- a/src/treq/testing.py
+++ b/src/treq/testing.py
@@ -197,7 +197,7 @@ class _SynchronousProducer:
         assert isinstance(body, (bytes, str)), msg
         if isinstance(body, str):
             self.body = body.encode('utf-8')
-        self.length = len(body)
+        self.length = len(self.body)
 
     def startProducing(self, consumer):
         """


### PR DESCRIPTION
Resolves https://github.com/twisted/treq/issues/412

These changes use the encoded body to set `_SynchronousProducer` length attribute instead of the input string. 